### PR TITLE
Fix IAsyncEnumerable<object> CreateStream for Value Types

### DIFF
--- a/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
@@ -58,6 +58,8 @@ internal sealed class CompilationAnalyzer
 
     public bool HasAnyStreamRequest => HasStreamRequests || HasStreamQueries || HasStreamCommands;
 
+    public bool HasAnyValueTypeStreamResponse => _requestMessages.Any(r => r.ResponseIsValueType);
+
     public bool HasNotifications => _notificationMessages.Any();
 
     public IEnumerable<RequestMessage> IRequestMessages =>

--- a/src/Mediator.SourceGenerator.Implementation/Analysis/RequestMessage.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/RequestMessage.cs
@@ -27,6 +27,7 @@ internal sealed class RequestMessage : SymbolMetadata<RequestMessage>
     }
 
     public string RequestFullName => Symbol.GetTypeSymbolFullName();
+    public bool ResponseIsValueType => ResponseSymbol!.IsValueType;
     public string ResponseFullName => ResponseSymbol!.GetTypeSymbolFullName();
 
     public void SetHandler(RequestMessageHandler handler) => Handler = handler;

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -609,8 +609,8 @@ namespace {{ MediatorNamespace }}
                 case {{ message.RequestFullName }} m: 
 				{
 					{{- if message.ResponseIsValueType }}
-                    var task = CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
-					return default;
+                    var value = CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
+					return AsyncWrapper(value);
 					{{ else }}
                     return CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
                     {{ end }}
@@ -626,6 +626,14 @@ namespace {{ MediatorNamespace }}
             ThrowInvalidMessage(message as global::Mediator.IStreamMessage);
             return default;
             {{ end }}
+			
+			static async IAsyncEnumerable<object> AsyncWrapper<T>(IAsyncEnumerable<T> wrapped) where T : struct
+            {
+                await foreach (var value in wrapped)
+                {
+                    yield return value;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -624,14 +624,14 @@ namespace {{ MediatorNamespace }}
             }
 			
             {{- if HasAnyValueTypeStreamResponse }}
-            static async IAsyncEnumerable<object> AsyncWrapper<T>(IAsyncEnumerable<T> wrapped, [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : struct
+            static async global::System.Collections.Generic.IAsyncEnumerable<object> AsyncWrapper<T>(global::System.Collections.Generic.IAsyncEnumerable<T> wrapped, [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default) where T : struct
             {
                 await foreach (var value in wrapped.WithCancellation(cancellationToken))
                 {
                     yield return value;
                 }
             }
-            {{ end }}	
+            {{ end }}
 			
             {{ else }}
             ThrowInvalidMessage(message as global::Mediator.IStreamMessage);

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -624,9 +624,9 @@ namespace {{ MediatorNamespace }}
             }
 			
             {{- if HasAnyValueTypeStreamResponse }}
-			static async IAsyncEnumerable<object> AsyncWrapper<T>(IAsyncEnumerable<T> wrapped) where T : struct
+            static async IAsyncEnumerable<object> AsyncWrapper<T>(IAsyncEnumerable<T> wrapped, [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : struct
             {
-                await foreach (var value in wrapped)
+                await foreach (var value in wrapped.WithCancellation(cancellationToken))
                 {
                     yield return value;
                 }

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -622,11 +622,8 @@ namespace {{ MediatorNamespace }}
                     return default;
                 }
             }
-            {{ else }}
-            ThrowInvalidMessage(message as global::Mediator.IStreamMessage);
-            return default;
-            {{ end }}
 			
+            {{- if HasAnyValueTypeStreamResponse }}
 			static async IAsyncEnumerable<object> AsyncWrapper<T>(IAsyncEnumerable<T> wrapped) where T : struct
             {
                 await foreach (var value in wrapped)
@@ -634,6 +631,12 @@ namespace {{ MediatorNamespace }}
                     yield return value;
                 }
             }
+            {{ end }}	
+			
+            {{ else }}
+            ThrowInvalidMessage(message as global::Mediator.IStreamMessage);
+            return default;
+            {{ end }}				
         }
 
         /// <summary>

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -606,7 +606,15 @@ namespace {{ MediatorNamespace }}
             switch (message)
             {
                 {{~ for message in IStreamMessages ~}}
-                case {{ message.RequestFullName }} m: return CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
+                case {{ message.RequestFullName }} m: 
+				{
+					{{- if message.ResponseIsValueType }}
+                    var task = CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
+					return default;
+					{{ else }}
+                    return CreateStream({{- message.ParameterModifier -}}m, cancellationToken);
+                    {{ end }}
+                }
                 {{~ end ~}}
                 default:
                 {

--- a/test/Mediator.Tests/StructResponseTests.cs
+++ b/test/Mediator.Tests/StructResponseTests.cs
@@ -15,10 +15,13 @@ public sealed class StructResponseTests
 
     public sealed record Query(Guid Id) : IQuery<Response>;
 
+    public sealed record Stream(Guid Id) : IStreamRequest<Response>;
+
     public sealed class Handler
         : IRequestHandler<Request, Response>,
           ICommandHandler<Command, Response>,
-          IQueryHandler<Query, Response>
+          IQueryHandler<Query, Response>,
+          IStreamRequestHandler<Stream, Response>
     {
         public ValueTask<Response> Handle(Request request, CancellationToken cancellationToken) =>
             new ValueTask<Response>(new Response(request.Id));
@@ -28,6 +31,15 @@ public sealed class StructResponseTests
 
         public ValueTask<Response> Handle(Query query, CancellationToken cancellationToken) =>
             new ValueTask<Response>(new Response(query.Id));
+
+        public async IAsyncEnumerable<Response> Handle(
+            Stream stream,
+            [EnumeratorCancellation] CancellationToken cancellationToken
+        )
+        {
+            await Task.Yield();
+            yield return new Response(stream.Id);
+        }
     }
 
     [Fact]
@@ -100,5 +112,43 @@ public sealed class StructResponseTests
 
         var response = await mediator.Send(message);
         Assert.Equal(id, ((Response)response!).Id);
+    }
+
+    [Fact]
+    public async Task Test_Stream()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+
+        var id = Guid.NewGuid();
+        var message = new Stream(id);
+
+        var response = mediator.CreateStream(message);
+        int count = 0;
+        await foreach (var value in response)
+        {
+            Assert.Equal(id, ((Response)value!).Id);
+            count++;
+        }
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task Test_Stream_Object()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+
+        var id = Guid.NewGuid();
+        object message = new Stream(id);
+
+        var response = mediator.CreateStream(message);
+        int count = 0;
+        await foreach (var value in response)
+        {
+            Assert.Equal(id, ((Response)value!).Id);
+            count++;
+        }
+
+        Assert.Equal(1, count);
     }
 }


### PR DESCRIPTION
This adds a special case for IAsyncEnumerable<object> CreateStream if the response type is a struct.
It then calls a wrapper method for the async object enumeration.
I chose the simple wrapper method approach, instead of writing some custom type as the automatically generated state machines for async enumerables contain quite a lot of optimization w.r.t IValueTaskSource etc. according to https://docs.microsoft.com/en-us/archive/msdn-magazine/2019/november/csharp-iterating-with-async-enumerables-in-csharp-8
Closes #36