### PR TITLE
Use global method reference instead of extension method

### DIFF
--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -626,7 +626,7 @@ namespace {{ MediatorNamespace }}
             {{- if HasAnyValueTypeStreamResponse }}
             static async global::System.Collections.Generic.IAsyncEnumerable<object> AsyncWrapper<T>(global::System.Collections.Generic.IAsyncEnumerable<T> wrapped, [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default) where T : struct
             {
-                await foreach (var value in wrapped.WithCancellation(cancellationToken))
+                await foreach (var value in global::System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation(wrapped, cancellationToken))
                 {
                     yield return value;
                 }


### PR DESCRIPTION
Funny thing: The previous fix works in the tests, but not in my actual product solution.
It does not compile with:
Error	CS1061	'IAsyncEnumerable<T>' does not contain a definition for 'WithCancellation' and no accessible extension method 'WithCancellation' accepting a first argument of type 'IAsyncEnumerable<T>' could be found (are you missing a using directive or an assembly reference?)

This is because the test projects have implicit usings enabled, which include the namespace for that particular extension method.

So instead of using the extension metho directly, call it via the fully qualified global reference to it.

I built a nuget package with my changes and verified that it now works in my product solution, I also verified that if I manually disable the implict usings in the test project the same error occurs.

I highly recommend disabling implicits usings for test projects, it's just an additional error source for source generation. (the same problem happened multiple times in the dotnet runtime repo for the logger srcgen)

This is still for #36 