### PR TITLE
Support Notification Handler Identification via Reflection

### DIFF
--- a/src/Mediator.SourceGenerator.Implementation/Analysis/NotificationMessage.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/NotificationMessage.cs
@@ -35,7 +35,7 @@ internal sealed class NotificationMessage : SymbolMetadata<NotificationMessage>
             var handlerTypeOfExpression = HandlerTypeOfExpression;
             foreach (var handler in _handlers)
             {
-                var getExpression = $"sp => sp.GetRequiredService<{handler.FullName}>()";
+                var getExpression = $"GetRequiredService<{handler.FullName}>()";
                 yield return $"services.Add(new SD({handlerTypeOfExpression}, {getExpression}, {ServiceLifetime}));";
             }
         }

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -79,6 +79,9 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<Dummy>();
 
             return services;
+			
+            [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+            static global::System.Func<global::System.IServiceProvider, T> GetRequiredService<T>() where T : notnull => sp => sp.GetRequiredService<T>();
         }
     }
 }

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -80,8 +80,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
 			
+			{{~ if HasNotifications ~}}
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             static global::System.Func<global::System.IServiceProvider, T> GetRequiredService<T>() where T : notnull => sp => sp.GetRequiredService<T>();
+			{{~ end ~}}
         }
     }
 }


### PR DESCRIPTION
This replaces the INotificationHandler DI Registration with a generic Method returning the registration functor. This allows reflection to identify the INotificationHandler Registration with the DI  to remove it for tests.
The test removes the specific INotificationHandler from the servicecollection and asserts that it is not called.
This is only done for Notification Handlers, as it is possible to register e.g. behaviors to block normal requesthandlers.

Closes #39