### PR TITLE
Fix defensive copy for non-readonly structs

### DIFF
--- a/benchmarks/Mediator.Benchmarks/Request/StructRequestBenchmarks.cs
+++ b/benchmarks/Mediator.Benchmarks/Request/StructRequestBenchmarks.cs
@@ -138,7 +138,7 @@ public class StructRequestBenchmarks
     [Benchmark]
     public ValueTask<SomeResponse> SendStructRequest_Mediator()
     {
-        return _concreteMediator.Send(in _request, CancellationToken.None);
+        return _concreteMediator.Send(_request, CancellationToken.None);
     }
 
     [Benchmark]

--- a/src/Mediator.SourceGenerator.Implementation/Analysis/SymbolMetadata.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/SymbolMetadata.cs
@@ -23,5 +23,5 @@ internal abstract class SymbolMetadata<T> : IEquatable<T?> where T : SymbolMetad
     public bool IsStruct => Symbol.TypeKind == TypeKind.Struct;
     public bool IsClass => !IsStruct;
     public bool IsReadOnly => Symbol.IsReadOnly;
-    public string ParameterModifier => IsStruct && IsReadOnly ? "in " : string.Empty;
+    public string ParameterModifier => string.Empty;
 }

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -140,7 +140,7 @@ namespace {{ MediatorNamespace }}
             _rootHandler = handler;
         }
 
-        public {{ wrapperType.ReturnTypeName }} Handle(in TRequest request, global::System.Threading.CancellationToken cancellationToken) =>
+        public {{ wrapperType.ReturnTypeName }} Handle(TRequest request, global::System.Threading.CancellationToken cancellationToken) =>
             _rootHandler(request, cancellationToken);
     }
     {{~ end ~}}

--- a/test/Mediator.Tests/BasicHandlerTests.cs
+++ b/test/Mediator.Tests/BasicHandlerTests.cs
@@ -186,7 +186,7 @@ public class BasicHandlerTests
         var addr = *(long*)&command;
 
         var commandHandler = sp.GetRequiredService<SomeStructCommandHandler>();
-        concrete.Send(in command).GetAwaiter().GetResult();
+        concrete.Send(command).GetAwaiter().GetResult();
         Assert.Contains(id, SomeStructCommandHandler.Ids);
         Assert.Contains(addr, SomeStructCommandHandler.Addresses);
     }
@@ -224,7 +224,7 @@ public class BasicHandlerTests
         var notificationHandler = sp.GetRequiredService<SomeStructNotificationHandler>();
         Assert.NotNull(notificationHandler);
 
-        concrete.Publish(in notification).GetAwaiter().GetResult();
+        concrete.Publish(notification).GetAwaiter().GetResult();
         Assert.Contains(id, SomeStructNotificationHandler.Ids);
         //Assert.Contains(addr, SomeStructNotificationHandler.Addresses);
     }

--- a/test/Mediator.Tests/CustomContainerTests.cs
+++ b/test/Mediator.Tests/CustomContainerTests.cs
@@ -40,7 +40,7 @@ public class CustomContainerTests
         SomeStructNotificationHandler.Ids.Clear();
         Assert.DoesNotContain(id, SomeStructNotificationHandler.Ids);
 
-        await concrete.Publish(in notification);
+        await concrete.Publish(notification);
         Assert.Contains(id, SomeStructNotificationHandler.Ids);
     }
 


### PR DESCRIPTION
Removes the in parameter modifier, as it leads to defensive copies and bad perf for non-readonly struct.
There is no generic constraint to force readonly.
I evaluated to add two Handle Methods (one with in, one without) but the code-churn was too high.
I also evaluated to have multiple Struct Wrapper Types, but the code churn again was too high.
This is the simpliest solution (for now) and let the JIT decide what to do with structs of a reasonable size.
I left the actual modifier in the template (just with string.Empty) to reduce code-churn on the template.

Closes #43