### PR TITLE
Disable implicit usings in tests

### DIFF
--- a/Mediator.sln
+++ b/Mediator.sln
@@ -11,6 +11,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.SourceGenerator", "src\Mediator.SourceGenerator\Mediator.SourceGenerator.csproj", "{D3F185A5-0145-4333-8CFF-548E3BD478DE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{ED1809FC-733B-4D9E-8FEE-70D3BB0BBD84}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.props = test\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Tests", "test\Mediator.Tests\Mediator.Tests.csproj", "{488A6892-3435-4E72-9B74-A847F2E4197F}"
 EndProject
@@ -48,17 +51,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleEndToEnd", "samples\S
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_files", "_files", "{FDAEEFFB-30BC-4BC2-9E76-2F98D801FC34}"
 	ProjectSection(SolutionItems) = preProject
+		.csharpierrc.json = .csharpierrc.json
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		Build.csproj = Build.csproj
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		LICENSE = LICENSE
 		NuGet.config = NuGet.config
 		README.md = README.md
 		version.json = version.json
-		.csharpierrc.json = .csharpierrc.json
-		Build.csproj = Build.csproj
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Tests.TransientLifetime", "test\Mediator.Tests.TransientLifetime\Mediator.Tests.TransientLifetime.csproj", "{4C18FD08-BCE4-4C6A-9D84-9A81C4561586}"
@@ -83,7 +86,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.MemAllocationTests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Tests.Common", "test\Mediator.Tests.Common\Mediator.Tests.Common.csproj", "{32DC3B96-7E6E-40B0-AA12-40656B2D0381}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediator.Samples.SourceGenerator.Tests", "test\Mediator.Samples.SourceGenerator.Tests\Mediator.Samples.SourceGenerator.Tests.csproj", "{8625B7F2-F974-47E7-ABF1-C75AB9C305B2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Samples.SourceGenerator.Tests", "test\Mediator.Samples.SourceGenerator.Tests\Mediator.Samples.SourceGenerator.Tests.csproj", "{8625B7F2-F974-47E7-ABF1-C75AB9C305B2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+  <PropertyGroup>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/test/Mediator.MemAllocationTests/NotificationTests.cs
+++ b/test/Mediator.MemAllocationTests/NotificationTests.cs
@@ -1,5 +1,6 @@
 using Mediator.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Mediator.MemAllocationTests;
 

--- a/test/Mediator.MemAllocationTests/RequestTests.cs
+++ b/test/Mediator.MemAllocationTests/RequestTests.cs
@@ -2,6 +2,8 @@ using JetBrains.dotMemoryUnit;
 using JetBrains.dotMemoryUnit.Kernel;
 using Mediator.Tests.Common;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Mediator.MemAllocationTests;

--- a/test/Mediator.MemAllocationTests/SomeNotificationMemAllocTracking.cs
+++ b/test/Mediator.MemAllocationTests/SomeNotificationMemAllocTracking.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.MemAllocationTests;
 
 public sealed record SomeNotificationMemAllocTracking(Guid Id) : INotification;

--- a/test/Mediator.MemAllocationTests/SomeRequestMemAllocTracking.cs
+++ b/test/Mediator.MemAllocationTests/SomeRequestMemAllocTracking.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.MemAllocationTests;
 
 public sealed record SomeRequestMemAllocTracking(Guid Id) : IRequest;

--- a/test/Mediator.SmokeTestConsole/Program.cs
+++ b/test/Mediator.SmokeTestConsole/Program.cs
@@ -2,6 +2,10 @@ using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using DICache = Mediator.Mediator.DICache;
 using LazyDICache = Mediator.Mediator.FastLazyValue<Mediator.Mediator.DICache>;
 

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/AssertExtensions.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/AssertExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using System;
 
 namespace Mediator.SourceGenerator.Tests;
 

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/Assertions.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/Assertions.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using System.Linq;
 
 namespace Mediator.SourceGenerator.Tests;
 

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/Fixture.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/Fixture.cs
@@ -1,7 +1,12 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Mediator.SourceGenerator.Tests;
 

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/ReportingTests.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/ReportingTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mediator.SourceGenerator.Tests;
 

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/SamplesTests.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/SamplesTests.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Mediator.SourceGenerator.Tests;
 
 using Microsoft.CodeAnalysis.Testing;

--- a/test/Mediator.SourceGenerator.Roslyn38.Tests/SourceGenVerifier.cs
+++ b/test/Mediator.SourceGenerator.Roslyn38.Tests/SourceGenVerifier.cs
@@ -3,7 +3,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 
 public static class CSharpSourceGeneratorVerifier<TSourceGenerator> where TSourceGenerator : ISourceGenerator, new()
 {

--- a/test/Mediator.Tests.Common/Fixture.cs
+++ b/test/Mediator.Tests.Common/Fixture.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.Common;
 
 public static class Allocations

--- a/test/Mediator.Tests.ScopedLifetime/ScopedLifetimeTests.cs
+++ b/test/Mediator.Tests.ScopedLifetime/ScopedLifetimeTests.cs
@@ -1,5 +1,6 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Mediator.Tests.ScopedLifetime;
 

--- a/test/Mediator.Tests/AbstractRequestHandlerTests.cs
+++ b/test/Mediator.Tests/AbstractRequestHandlerTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/BasicHandlerTests.cs
+++ b/test/Mediator.Tests/BasicHandlerTests.cs
@@ -1,7 +1,8 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
-using System.Diagnostics;
-using System.Reflection;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using static Mediator.Tests.OpenConstrainedGenericsTests;
 
 namespace Mediator.Tests;

--- a/test/Mediator.Tests/Fixture.cs
+++ b/test/Mediator.Tests/Fixture.cs
@@ -1,4 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/OpenConstrainedGenericsTests.cs
+++ b/test/Mediator.Tests/OpenConstrainedGenericsTests.cs
@@ -1,6 +1,10 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/Pipeline/CommandSpecificPipeline.cs
+++ b/test/Mediator.Tests/Pipeline/CommandSpecificPipeline.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.Pipeline;
 
 public sealed class CommandSpecificPipeline<TCommand, TResponse> : IPipelineBehavior<TCommand, TResponse>

--- a/test/Mediator.Tests/Pipeline/GenericPipeline.cs
+++ b/test/Mediator.Tests/Pipeline/GenericPipeline.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.Pipeline;
 

--- a/test/Mediator.Tests/Pipeline/IPipelineTestData.cs
+++ b/test/Mediator.Tests/Pipeline/IPipelineTestData.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.Pipeline;
 
 public interface IPipelineTestData

--- a/test/Mediator.Tests/Pipeline/PipelineTests.cs
+++ b/test/Mediator.Tests/Pipeline/PipelineTests.cs
@@ -1,5 +1,8 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.Pipeline;
 

--- a/test/Mediator.Tests/Pipeline/SomePipeline.cs
+++ b/test/Mediator.Tests/Pipeline/SomePipeline.cs
@@ -1,5 +1,8 @@
 using Mediator.Tests.TestTypes;
+using System;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.Pipeline;
 

--- a/test/Mediator.Tests/Pipeline/SomeStreamingPipeline.cs
+++ b/test/Mediator.Tests/Pipeline/SomeStreamingPipeline.cs
@@ -1,5 +1,7 @@
 using Mediator.Tests.TestTypes;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Mediator.Tests.Pipeline;
 

--- a/test/Mediator.Tests/Pipeline/StreamingPipelineTests.cs
+++ b/test/Mediator.Tests/Pipeline/StreamingPipelineTests.cs
@@ -1,5 +1,7 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.Pipeline;
 

--- a/test/Mediator.Tests/PolymorphicDispatchTests.cs
+++ b/test/Mediator.Tests/PolymorphicDispatchTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/RequestInheritanceTests.cs
+++ b/test/Mediator.Tests/RequestInheritanceTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/SenderTests.cs
+++ b/test/Mediator.Tests/SenderTests.cs
@@ -1,5 +1,7 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/SmokeTests.FastLazy.cs
+++ b/test/Mediator.Tests/SmokeTests.FastLazy.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Threading.Tasks;
 using DICache = Mediator.Mediator.DICache;
 using LazyDICache = Mediator.Mediator.FastLazyValue<Mediator.Mediator.DICache>;
 

--- a/test/Mediator.Tests/SmokeTests.cs
+++ b/test/Mediator.Tests/SmokeTests.cs
@@ -1,4 +1,6 @@
 using Mediator.Tests.TestTypes;
+using System;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/StreamingTests.cs
+++ b/test/Mediator.Tests/StreamingTests.cs
@@ -1,4 +1,8 @@
 using Mediator.Tests.TestTypes;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests;
 

--- a/test/Mediator.Tests/StructResponseTests.cs
+++ b/test/Mediator.Tests/StructResponseTests.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests;
 
 public sealed class StructResponseTests

--- a/test/Mediator.Tests/TestTypes/SomeCommand.cs
+++ b/test/Mediator.Tests/TestTypes/SomeCommand.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeCommand(Guid Id) : ICommand<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeCommandHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeCommandHandler.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.TestTypes;
 

--- a/test/Mediator.Tests/TestTypes/SomeNotification.cs
+++ b/test/Mediator.Tests/TestTypes/SomeNotification.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.TestTypes;
 
 public interface ISomeNotification : INotification

--- a/test/Mediator.Tests/TestTypes/SomeNotificationHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeNotificationHandler.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.TestTypes;
 

--- a/test/Mediator.Tests/TestTypes/SomeOtherNotificationHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeOtherNotificationHandler.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.TestTypes;
 

--- a/test/Mediator.Tests/TestTypes/SomeQuery.cs
+++ b/test/Mediator.Tests/TestTypes/SomeQuery.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeQuery(Guid Id) : IQuery<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeQueryHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeQueryHandler.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed class SomeQueryHandler : IQueryHandler<SomeQuery, SomeResponse>

--- a/test/Mediator.Tests/TestTypes/SomeRequest.cs
+++ b/test/Mediator.Tests/TestTypes/SomeRequest.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeRequest(Guid Id) : IRequest<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeRequestHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeRequestHandler.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mediator.Tests.TestTypes;
 

--- a/test/Mediator.Tests/TestTypes/SomeResponse.cs
+++ b/test/Mediator.Tests/TestTypes/SomeResponse.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeResponse(Guid Id)

--- a/test/Mediator.Tests/TestTypes/SomeStreamingCommand.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingCommand.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeStreamingCommand(Guid Id) : IStreamCommand<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeStreamingCommandStruct.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingCommandStruct.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.TestTypes;
 
 public record struct SomeStreamingCommandStruct(Guid Id) : IStreamCommand<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeStreamingQuery.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingQuery.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeStreamingQuery(Guid Id) : IStreamQuery<SomeResponse>;

--- a/test/Mediator.Tests/TestTypes/SomeStreamingRequest.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingRequest.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeStreamingRequest(Guid Id) : IStreamRequest<SomeResponse>;


### PR DESCRIPTION
Disable implict usings for tests to prevent issues with missing fully qualified type names in source generator.

This is to prevent bugs as seen in in PR #38

Disable via props file in tests folder, let Resharper fix the missing usings.