### PR TITLE
Fix thread safety issue in ISourceGenerator/IIncrementalGenerator implementations

### DIFF
--- a/src/Mediator.SourceGenerator.Roslyn38/MediatorGenerator.cs
+++ b/src/Mediator.SourceGenerator.Roslyn38/MediatorGenerator.cs
@@ -41,7 +41,7 @@ public sealed class MediatorGenerator : ISourceGenerator
         CompilationAnalyzer = compilationAnalyzer;
 
         var mediatorImplementationGenerator = new MediatorImplementationGenerator();
-        mediatorImplementationGenerator.Generate(CompilationAnalyzer);
+        mediatorImplementationGenerator.Generate(compilationAnalyzer);
     }
 
     public void Initialize(GeneratorInitializationContext context)

--- a/src/Mediator.SourceGenerator.Roslyn38/MediatorGenerator.cs
+++ b/src/Mediator.SourceGenerator.Roslyn38/MediatorGenerator.cs
@@ -3,7 +3,7 @@ namespace Mediator.SourceGenerator;
 [Generator]
 public sealed class MediatorGenerator : ISourceGenerator
 {
-    internal CompilationAnalyzer? CompilationAnalyzer { get; private set; }
+    internal CompilationAnalyzer? CompilationAnalyzer;
 
     public void Execute(GeneratorExecutionContext context)
     {
@@ -33,10 +33,12 @@ public sealed class MediatorGenerator : ISourceGenerator
             context.CancellationToken
         );
 
-        CompilationAnalyzer = new CompilationAnalyzer(in analyzerContext);
+        var compilationAnalyzer = new CompilationAnalyzer(in analyzerContext);
 
-        CompilationAnalyzer.Initialize();
-        CompilationAnalyzer.Analyze();
+        compilationAnalyzer.Initialize();
+        compilationAnalyzer.Analyze();
+
+        CompilationAnalyzer = compilationAnalyzer;
 
         var mediatorImplementationGenerator = new MediatorImplementationGenerator();
         mediatorImplementationGenerator.Generate(CompilationAnalyzer);

--- a/src/Mediator.SourceGenerator.Roslyn40/IncrementalMediatorGenerator.cs
+++ b/src/Mediator.SourceGenerator.Roslyn40/IncrementalMediatorGenerator.cs
@@ -5,7 +5,7 @@ namespace Mediator.SourceGenerator;
 [Generator]
 public sealed class IncrementalMediatorGenerator : IIncrementalGenerator
 {
-    internal CompilationAnalyzer? CompilationAnalyzer { get; private set; }
+    internal CompilationAnalyzer? CompilationAnalyzer;
 
     private void ExecuteInternal(
         in SourceProductionContext context,
@@ -24,19 +24,21 @@ public sealed class IncrementalMediatorGenerator : IIncrementalGenerator
             context.CancellationToken
         );
 
-        CompilationAnalyzer = new CompilationAnalyzer(in analyzerContext);
+        var compilationAnalyzer = new CompilationAnalyzer(in analyzerContext);
 
-        CompilationAnalyzer.Initialize();
-        CompilationAnalyzer.Analyze();
+        compilationAnalyzer.Initialize();
+        compilationAnalyzer.Analyze();
+
+        CompilationAnalyzer = compilationAnalyzer;
 
         var mediatorImplementationGenerator = new MediatorImplementationGenerator();
-        mediatorImplementationGenerator.Generate(CompilationAnalyzer);
+        mediatorImplementationGenerator.Generate(compilationAnalyzer);
     }
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(
-            context =>
+            static context =>
             {
                 var generatorVersion = Versioning.GetVersion();
 


### PR DESCRIPTION
Fixes #55 

Both the old 3.8 and newer 4.0 generator implementations were assigning to an instance member and rereading the instance member to invoke methods. This created a race condition in which these methods were invoked in parallel across different threads for the same `CompilationAnalyzer` instance, which isn't thread safe. Invoking these methods on a local variable instead fixes this race condition. The reason it is an instance member is because it's used in unit-testing (to verify analysis outcomes), and in these cases the analysis is ran only once.

#55 suggests making use of `HashSet<>`s in a thread safe manner, but this fix should suffice, as the `CompilationAnalyzer` isn't expected to be invoked in parallel.  