### PR TITLE
Improved error handling and XML docs

### DIFF
--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -414,12 +414,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(request, nameof(request));
+                    ThrowInvalidRequest(request, nameof(request));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(request);
+            ThrowInvalidRequest(request, nameof(request));
             return default;
             {{ end }}
         }
@@ -528,12 +528,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(command, nameof(command));
+                    ThrowInvalidCommand(command, nameof(command));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(command);
+            ThrowInvalidCommand(command, nameof(command));
             return default;
             {{ end }}
         }
@@ -642,12 +642,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(query, nameof(query));
+                    ThrowInvalidQuery(query, nameof(query));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(query);
+            ThrowInvalidQuery(query, nameof(query));
             return default;
             {{ end }}
         }
@@ -1010,9 +1010,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidMessage<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IMessage)
+            else if (!(msg is global::Mediator.IMessage))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1021,9 +1021,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidRequest<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseRequest)
+            else if (!(msg is global::Mediator.IBaseRequest))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1032,9 +1032,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidCommand<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseCommand)
+            else if (!(msg is global::Mediator.IBaseCommand))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1043,9 +1043,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidQuery<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseQuery)
+            else if (!(msg is global::Mediator.IBaseQuery))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1054,9 +1054,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidStreamMessage<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IStreamMessage)
+            else if (!(msg is global::Mediator.IStreamMessage))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1065,9 +1065,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidStreamRequest<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseStreamRequest)
+            else if (!(msg is global::Mediator.IBaseStreamRequest))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1076,9 +1076,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidStreamCommand<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseStreamCommand)
+            else if (!(msg is global::Mediator.IBaseStreamCommand))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1087,9 +1087,9 @@ namespace {{ MediatorNamespace }}
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowInvalidStreamQuery<T>(T msg, string paramName = null)
         {
-            if (msg is null)
+            if (msg == null)
                 ThrowArgumentNull(paramName);
-            else if (msg is not global::Mediator.IBaseStreamQuery)
+            else if (!(msg is global::Mediator.IBaseStreamQuery))
                 ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
@@ -1105,15 +1105,15 @@ namespace {{ MediatorNamespace }}
 
         private static void ThrowIfNull<T>(T argument, string paramName)
         {
-            if (argument is null)
+            if (argument == null)
                 ThrowArgumentNull(paramName);
         }
 
         private static void ThrowInvalidNotification<T>(T argument, string paramName)
         {
-            if (argument is null)
+            if (argument == null)
                 ThrowArgumentNull(paramName);
-            else if (argument is not global::Mediator.INotification)
+            else if (!(argument is global::Mediator.INotification))
                 ThrowInvalidMessage(argument);
         }
 

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -384,6 +384,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Send request.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if request does not implement <see cref="global::Mediator.IRequest{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="request">Incoming request</param>
@@ -448,12 +449,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(request, nameof(request));
+                    ThrowInvalidRequest(request, nameof(request));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(request);
+            ThrowInvalidRequest(request, nameof(request));
             return default;
             {{ end }}
         }
@@ -461,6 +462,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Create stream for request.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if request does not implement <see cref="global::Mediator.IStreamRequest{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="request">Incoming message</param>
@@ -483,12 +485,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(request, nameof(request));
+                    ThrowInvalidStreamRequest(request, nameof(request));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(request);
+            ThrowInvalidStreamRequest(request, nameof(request));
             return default;
             {{ end }}
         }
@@ -496,6 +498,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Send command.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if command does not implement <see cref="global::Mediator.ICommand{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="command">Incoming command</param>
@@ -560,12 +563,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(command, nameof(command));
+                    ThrowInvalidCommand(command, nameof(command));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(command);
+            ThrowInvalidCommand(command, nameof(command));
             return default;
             {{ end }}
         }
@@ -573,6 +576,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Create stream for command.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if command does not implement <see cref="global::Mediator.IStreamCommand{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="command">Incoming message</param>
@@ -595,12 +599,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(command, nameof(command));
+                    ThrowInvalidStreamCommand(command, nameof(command));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(command);
+            ThrowInvalidStreamCommand(command, nameof(command));
             return default;
             {{ end }}
         }
@@ -608,6 +612,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Send query.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if query does not implement <see cref="global::Mediator.IQuery{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="query">Incoming query</param>
@@ -672,12 +677,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(query, nameof(query));
+                    ThrowInvalidQuery(query, nameof(query));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(query);
+            ThrowInvalidQuery(query, nameof(query));
             return default;
             {{ end }}
         }
@@ -685,6 +690,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Create stream for query.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if query does not implement <see cref="global::Mediator.IStreamQuery{TResponse}"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="query">Incoming message</param>
@@ -707,12 +713,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(query, nameof(query));
+                    ThrowInvalidStreamQuery(query, nameof(query));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(query);
+            ThrowInvalidStreamQuery(query, nameof(query));
             return default;
             {{ end }}
         }
@@ -720,6 +726,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Send message.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if message does not implement <see cref="global::Mediator.IMessage"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="message">Incoming message</param>
@@ -738,12 +745,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(message as global::Mediator.IMessage, nameof(message));
+                    ThrowInvalidMessage(message, nameof(message));
                     return default;
                 }
             }
             {{ else }}
-            ThrowInvalidMessage(message as global::Mediator.IMessage);
+            ThrowInvalidMessage(message, nameof(message));
             return default;
             {{ end }}
         }
@@ -751,6 +758,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Create stream.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if message does not implement <see cref="global::Mediator.IStreamMessage"/>.
         /// Throws <see cref="global::Mediator.MissingMessageHandlerException"/> if no handler is registered.
         /// </summary>
         /// <param name="message">Incoming message</param>
@@ -777,7 +785,7 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowArgumentNullOrInvalidMessage(message as global::Mediator.IStreamMessage, nameof(message));
+                    ThrowInvalidStreamMessage(message, nameof(message));
                     return default;
                 }
             }
@@ -793,7 +801,7 @@ namespace {{ MediatorNamespace }}
             {{ end }}
 
             {{ else }}
-            ThrowInvalidMessage(message as global::Mediator.IStreamMessage);
+            ThrowInvalidStreamMessage(message, nameof(message));
             return default;
             {{ end }}
         }
@@ -801,6 +809,8 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Publish notification.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::System.AggregateException"/> if handlers throw exception(s).
+        /// Drops messages 
         /// </summary>
         /// <param name="notification">Incoming notification</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -823,6 +833,7 @@ namespace {{ MediatorNamespace }}
                 }
             }
             {{ else }}
+            ThrowIfNull(notification, nameof(notification));
             return default;
             {{ end }}
         }
@@ -833,6 +844,7 @@ namespace {{ MediatorNamespace }}
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
         {{- end }}
+        /// Throws <see cref="global::System.AggregateException"/> if handlers throw exception(s).
         /// </summary>
         /// <param name="notification">Incoming message</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -960,6 +972,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Publish notification.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::System.AggregateException"/> if handlers throw exception(s).
         /// </summary>
         /// <param name="notification">Incoming notification</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -988,8 +1001,96 @@ namespace {{ MediatorNamespace }}
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidMessage(object msg) =>
+        private static void ThrowMissingHandler(object msg) =>
             throw new global::Mediator.MissingMessageHandlerException(msg);
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidMessage(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IMessage)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidRequest(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseRequest)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidCommand(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseCommand)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidQuery(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseQuery)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidStreamMessage(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IStreamMessage)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidStreamRequest(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseStreamRequest)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidStreamCommand(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseStreamCommand)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
+
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidStreamQuery(object msg, string paramName = null)
+        {
+            if (msg is null)
+                ThrowArgumentNull(paramName);
+            else if (msg is not global::Mediator.IBaseStreamQuery)
+                throw new global::Mediator.InvalidMessageException(msg);
+            else
+                ThrowMissingHandler(msg);
+        }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
         private static void ThrowArgumentNull(string paramName) =>
@@ -1000,19 +1101,6 @@ namespace {{ MediatorNamespace }}
             if (argument is null)
             {
                 ThrowArgumentNull(paramName);
-            }
-        }
-
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowArgumentNullOrInvalidMessage(object msg, string paramName)
-        {
-            if (msg is null)
-            {
-                ThrowArgumentNull(paramName);
-            }
-            else
-            {
-                ThrowInvalidMessage(msg);
             }
         }
 

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -809,8 +809,9 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Publish notification.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if notification does not implement <see cref="global::Mediator.INotification"/>.
         /// Throws <see cref="global::System.AggregateException"/> if handlers throw exception(s).
-        /// Drops messages 
+        /// Drops messages
         /// </summary>
         /// <param name="notification">Incoming notification</param>
         /// <param name="cancellationToken">Cancellation token</param>
@@ -828,12 +829,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowIfNull(notification, nameof(notification));
+                    ThrowInvalidNotification(notification, nameof(notification));
                     return default;
                 }
             }
             {{ else }}
-            ThrowIfNull(notification, nameof(notification));
+            ThrowInvalidNotification(notification, nameof(notification));
             return default;
             {{ end }}
         }
@@ -972,6 +973,7 @@ namespace {{ MediatorNamespace }}
         /// <summary>
         /// Publish notification.
         /// Throws <see cref="global::System.ArgumentNullException"/> if message is null.
+        /// Throws <see cref="global::Mediator.InvalidMessageException"/> if notification does not implement <see cref="global::Mediator.INotification"/>.
         /// Throws <see cref="global::System.AggregateException"/> if handlers throw exception(s).
         /// </summary>
         /// <param name="notification">Incoming notification</param>
@@ -991,11 +993,12 @@ namespace {{ MediatorNamespace }}
                 {{~ end ~}}
                 default:
                 {
-                    ThrowIfNull(notification, nameof(notification));
+                    ThrowInvalidNotification(notification, nameof(notification));
                     return default;
                 }
             }
             {{ else }}
+            ThrowInvalidNotification(notification, nameof(notification));
             return default;
             {{ end }}
         }
@@ -1005,89 +1008,89 @@ namespace {{ MediatorNamespace }}
             throw new global::Mediator.MissingMessageHandlerException(msg);
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidMessage(object msg, string paramName = null)
+        private static void ThrowInvalidMessage<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IMessage)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidRequest(object msg, string paramName = null)
+        private static void ThrowInvalidRequest<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseRequest)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidCommand(object msg, string paramName = null)
+        private static void ThrowInvalidCommand<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseCommand)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidQuery(object msg, string paramName = null)
+        private static void ThrowInvalidQuery<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseQuery)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidStreamMessage(object msg, string paramName = null)
+        private static void ThrowInvalidStreamMessage<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IStreamMessage)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidStreamRequest(object msg, string paramName = null)
+        private static void ThrowInvalidStreamRequest<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseStreamRequest)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidStreamCommand(object msg, string paramName = null)
+        private static void ThrowInvalidStreamCommand<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseStreamCommand)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        private static void ThrowInvalidStreamQuery(object msg, string paramName = null)
+        private static void ThrowInvalidStreamQuery<T>(T msg, string paramName = null)
         {
             if (msg is null)
                 ThrowArgumentNull(paramName);
             else if (msg is not global::Mediator.IBaseStreamQuery)
-                throw new global::Mediator.InvalidMessageException(msg);
+                ThrowInvalidMessage(msg);
             else
                 ThrowMissingHandler(msg);
         }
@@ -1096,12 +1099,22 @@ namespace {{ MediatorNamespace }}
         private static void ThrowArgumentNull(string paramName) =>
             throw new global::System.ArgumentNullException(paramName);
 
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        private static void ThrowInvalidMessage<T>(T msg) =>
+            throw new global::Mediator.InvalidMessageException(msg);
+
         private static void ThrowIfNull<T>(T argument, string paramName)
         {
             if (argument is null)
-            {
                 ThrowArgumentNull(paramName);
-            }
+        }
+
+        private static void ThrowInvalidNotification<T>(T argument, string paramName)
+        {
+            if (argument is null)
+                ThrowArgumentNull(paramName);
+            else if (argument is not global::Mediator.INotification)
+                ThrowInvalidMessage(argument);
         }
 
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]

--- a/src/Mediator/IMediator.cs
+++ b/src/Mediator/IMediator.cs
@@ -1,3 +1,9 @@
 namespace Mediator;
 
+/// <summary>
+/// Mediator instance for sending requests, commands, queries and their streaming counterparts (<see cref="IAsyncEnumerable{T}"/>).
+/// Also for publushing notifications.
+/// Use the concrete Mediator implementation for the highest performance (monomorphized method overloads per T available).
+/// Can use the <see cref="ISender"/> and <see cref="IPublisher"/> for requests/commands/queries and notifications respectively.
+/// </summary>
 public interface IMediator : ISender, IPublisher { }

--- a/src/Mediator/IMediator.cs
+++ b/src/Mediator/IMediator.cs
@@ -2,7 +2,7 @@ namespace Mediator;
 
 /// <summary>
 /// Mediator instance for sending requests, commands, queries and their streaming counterparts (<see cref="IAsyncEnumerable{T}"/>).
-/// Also for publushing notifications.
+/// Also for publishing notifications.
 /// Use the concrete Mediator implementation for the highest performance (monomorphized method overloads per T available).
 /// Can use the <see cref="ISender"/> and <see cref="IPublisher"/> for requests/commands/queries and notifications respectively.
 /// </summary>

--- a/src/Mediator/IPublisher.cs
+++ b/src/Mediator/IPublisher.cs
@@ -8,6 +8,7 @@ public interface IPublisher
     /// <summary>
     /// Publish notification.
     /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if notification does not implement <see cref="INotification"/>.
     /// Throws <see cref="AggregateException"/> if handlers throw exceptions.
     /// </summary>
     /// <param name="notification">Incoming notification</param>
@@ -19,6 +20,7 @@ public interface IPublisher
     /// <summary>
     /// Publish notification.
     /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if notification does not implement <see cref="INotification"/>.
     /// Throws <see cref="AggregateException"/> if handlers throw exception(s).
     /// Drops messages
     /// </summary>

--- a/src/Mediator/IPublisher.cs
+++ b/src/Mediator/IPublisher.cs
@@ -1,9 +1,29 @@
 namespace Mediator;
 
+/// <summary>
+/// Mediator instance for publishing notifications
+/// </summary>
 public interface IPublisher
 {
+    /// <summary>
+    /// Publish notification.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="AggregateException"/> if handlers throw exceptions.
+    /// </summary>
+    /// <param name="notification">Incoming notification</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
         where TNotification : INotification;
 
+    /// <summary>
+    /// Publish notification.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="AggregateException"/> if handlers throw exception(s).
+    /// Drops messages
+    /// </summary>
+    /// <param name="notification">Incoming notification</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask Publish(object notification, CancellationToken cancellationToken = default);
 }

--- a/src/Mediator/ISender.cs
+++ b/src/Mediator/ISender.cs
@@ -1,29 +1,105 @@
 namespace Mediator;
 
+/// <summary>
+/// Mediator instance for sending requests, queries, commands,
+/// as well as their streaming counterparts (<see cref="IAsyncEnumerable{T}"/>).
+/// </summary>
 public interface ISender
 {
+    /// <summary>
+    /// Send request.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if request does not implement <see cref="IRequest{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="request">Incoming request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Send command.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if command does not implement <see cref="ICommand{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="command">Incoming command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask<TResponse> Send<TResponse>(ICommand<TResponse> command, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Send query.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if query does not implement <see cref="IQuery{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="query">Incoming query</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask<TResponse> Send<TResponse>(IQuery<TResponse> query, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Send message.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if message does not implement <see cref="IMessage"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="message">Incoming message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task</returns>
     ValueTask<object?> Send(object message, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Create stream for query.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if query does not implement <see cref="IStreamQuery{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="query">Incoming message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Async enumerable</returns>
     IAsyncEnumerable<TResponse> CreateStream<TResponse>(
         IStreamQuery<TResponse> query,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Create stream for request.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if request does not implement <see cref="IStreamRequest{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="request">Incoming message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Async enumerable</returns>
     IAsyncEnumerable<TResponse> CreateStream<TResponse>(
         IStreamRequest<TResponse> request,
         CancellationToken cancellationToken = default
     );
 
+    /// <summary>
+    /// Create stream for command.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if command does not implement <see cref="IStreamCommand{TResponse}"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="command">Incoming message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Async enumerable</returns>
     IAsyncEnumerable<TResponse> CreateStream<TResponse>(
         IStreamCommand<TResponse> command,
         CancellationToken cancellationToken = default
     );
 
-    IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Create stream.
+    /// Throws <see cref="ArgumentNullException"/> if message is null.
+    /// Throws <see cref="InvalidMessageException"/> if message does not implement <see cref="IStreamMessage"/>.
+    /// Throws <see cref="MissingMessageHandlerException"/> if no handler is registered.
+    /// </summary>
+    /// <param name="message">Incoming message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Async enumerable</returns>
+    IAsyncEnumerable<object?> CreateStream(object message, CancellationToken cancellationToken = default);
 }

--- a/src/Mediator/InvalidMessageException.cs
+++ b/src/Mediator/InvalidMessageException.cs
@@ -1,0 +1,16 @@
+namespace Mediator;
+
+/// <summary>
+/// Exception thrown when Mediator receives messages that don't derive from the correct interfaces
+/// from Mediator.Abstractions.
+/// </summary>
+public class InvalidMessageException : Exception
+{
+    public object? MediatorMessage { get; }
+
+    public InvalidMessageException(object? message)
+        : base("Tried to send/publish invalid message type to Mediator: " + message?.GetType().FullName ?? "Unknown")
+    {
+        MediatorMessage = message;
+    }
+}

--- a/src/Mediator/Messages/IStreamCommand.cs
+++ b/src/Mediator/Messages/IStreamCommand.cs
@@ -1,3 +1,5 @@
-﻿namespace Mediator;
+namespace Mediator;
 
-public interface IStreamCommand<out TResponse> : IStreamMessage { }
+public interface IBaseStreamCommand : IStreamMessage { }
+
+public interface IStreamCommand<out TResponse> : IBaseStreamCommand { }

--- a/src/Mediator/Messages/IStreamQuery.cs
+++ b/src/Mediator/Messages/IStreamQuery.cs
@@ -1,3 +1,5 @@
-﻿namespace Mediator;
+namespace Mediator;
 
-public interface IStreamQuery<out TResponse> : IStreamMessage { }
+public interface IBaseStreamQuery : IStreamMessage { }
+
+public interface IStreamQuery<out TResponse> : IBaseStreamQuery { }

--- a/src/Mediator/Messages/IStreamRequest.cs
+++ b/src/Mediator/Messages/IStreamRequest.cs
@@ -1,3 +1,5 @@
-﻿namespace Mediator;
+namespace Mediator;
 
-public interface IStreamRequest<out TResponse> : IStreamMessage { }
+public interface IBaseStreamRequest : IStreamMessage { }
+
+public interface IStreamRequest<out TResponse> : IBaseStreamRequest { }

--- a/src/Mediator/MissingMessageHandlerException.cs
+++ b/src/Mediator/MissingMessageHandlerException.cs
@@ -1,5 +1,9 @@
 namespace Mediator;
 
+/// <summary>
+/// Exception that is thrown when Mediator receives messages
+/// that have no registered handlers.
+/// </summary>
 public class MissingMessageHandlerException : Exception
 {
     public object? MediatorMessage { get; }

--- a/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
+++ b/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
@@ -10,6 +10,7 @@
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);MSG0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
+++ b/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
@@ -34,6 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
+++ b/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
@@ -10,6 +10,7 @@
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);MSG0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
+++ b/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
@@ -34,6 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests/BasicHandlerTests.cs
+++ b/test/Mediator.Tests/BasicHandlerTests.cs
@@ -352,6 +352,21 @@ public class BasicHandlerTests
     }
 
     [Fact]
+    public async Task Test_Notification_Handler_NonNull_NonNotification()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var notofication = Unsafe.As<object, SomeNotification>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Publish(message));
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Publish(notofication));
+    }
+
+    [Fact]
     public async Task Test_Multiple_Notification_Handlers()
     {
         var (sp, mediator) = Fixture.GetMediator();

--- a/test/Mediator.Tests/BasicHandlerTests.cs
+++ b/test/Mediator.Tests/BasicHandlerTests.cs
@@ -57,11 +57,39 @@ public class BasicHandlerTests
         var (_, mediator) = Fixture.GetMediator();
         var concrete = (Mediator)mediator;
 
-        var id = Guid.NewGuid();
-
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.Send((IRequest<SomeResponse>)null!));
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.Send(null!));
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await concrete.Send((SomeRequest)null!));
+    }
+
+    [Fact]
+    public async Task Test_Request_Handler_NonNull_NonRequest()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var request = Unsafe.As<object, IRequest>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(message));
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(request));
+    }
+
+    [Fact]
+    public async Task Test_Request_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var request = new SomeRequestWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send((object)request));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send(request));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await concrete.Send(request));
     }
 
     [Fact]
@@ -110,6 +138,36 @@ public class BasicHandlerTests
     }
 
     [Fact]
+    public async Task Test_Query_Handler_NonNull_NonQuery()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var query = Unsafe.As<object, IQuery<SomeResponse>>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(message));
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(query));
+    }
+
+    [Fact]
+    public async Task Test_Query_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var query = new SomeQueryWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send((object)query));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send(query));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await concrete.Send(query));
+    }
+
+    [Fact]
     public async Task Test_Command_Handler()
     {
         var (sp, mediator) = Fixture.GetMediator();
@@ -144,6 +202,36 @@ public class BasicHandlerTests
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.Send((ICommand<SomeResponse>)null!));
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.Send(null!));
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await concrete.Send((SomeCommand)null!));
+    }
+
+    [Fact]
+    public async Task Test_Command_Handler_NonNull_NonCommand()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var command = Unsafe.As<object, ICommand>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(message));
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.Send(command));
+    }
+
+    [Fact]
+    public async Task Test_Command_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var command = new SomeCommandWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send((object)command));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await mediator.Send(command));
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await concrete.Send(command));
     }
 
     [Fact]

--- a/test/Mediator.Tests/Mediator.Tests.csproj
+++ b/test/Mediator.Tests/Mediator.Tests.csproj
@@ -10,6 +10,7 @@
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <LangVersion>preview</LangVersion>
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
+    <NoWarn>$(NoWarn);MSG0005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests/Mediator.Tests.csproj
+++ b/test/Mediator.Tests/Mediator.Tests.csproj
@@ -34,6 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests/SenderTests.cs
+++ b/test/Mediator.Tests/SenderTests.cs
@@ -84,6 +84,6 @@ public sealed class SenderTests
         object obj = new { Id = id };
 
         var request = Unsafe.As<object, IRequest>(ref obj);
-        await Assert.ThrowsAsync<MissingMessageHandlerException>(async () => await sender.Send(request));
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await sender.Send(request));
     }
 }

--- a/test/Mediator.Tests/StreamingTests.cs
+++ b/test/Mediator.Tests/StreamingTests.cs
@@ -1,6 +1,7 @@
 using Mediator.Tests.TestTypes;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,7 @@ public sealed class StreamingTests
 {
     public static IEnumerable<IStreamMessage[]> TestMessages = new IStreamMessage[][]
     {
+        new IStreamMessage[] { new SomeStreamingRequest(Guid.NewGuid()) },
         new IStreamMessage[] { new SomeStreamingQuery(Guid.NewGuid()) },
         new IStreamMessage[] { new SomeStreamingCommand(Guid.NewGuid()) },
         new IStreamMessage[] { new SomeStreamingQuery(Guid.NewGuid()) },
@@ -155,5 +157,168 @@ public sealed class StreamingTests
         }
 
         Assert.Equal(1, counter);
+    }
+
+    [Fact]
+    public async Task Test_StreamQuery_Handler_Null_Input()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await mediator.CreateStream((IStreamQuery<SomeResponse>)null!).ToListAsync()
+        );
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.CreateStream(null!).ToListAsync());
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await concrete.CreateStream((SomeStreamingQuery)null!).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamQuery_Handler_NonNull_NonQuery()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var query = Unsafe.As<object, IStreamQuery<SomeResponse>>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            async () => await mediator.CreateStream(message).ToListAsync()
+        );
+        await Assert.ThrowsAsync<InvalidMessageException>(async () => await mediator.CreateStream(query).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Test_StreamQuery_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var query = new SomeStreamingQueryWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream((object)query).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream(query).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await concrete.CreateStream(query).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamCommand_Handler_Null_Input()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await mediator.CreateStream((IStreamCommand<SomeResponse>)null!).ToListAsync()
+        );
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.CreateStream(null!).ToListAsync());
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await concrete.CreateStream((SomeStreamingCommand)null!).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamCommand_Handler_NonNull_NonCommand()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var command = Unsafe.As<object, IStreamCommand<SomeResponse>>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            async () => await mediator.CreateStream(message).ToListAsync()
+        );
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            async () => await mediator.CreateStream(command).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamCommand_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var command = new SomeStreamingCommandWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream((object)command).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream(command).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await concrete.CreateStream(command).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamRequest_Handler_Null_Input()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await mediator.CreateStream((IStreamRequest<SomeResponse>)null!).ToListAsync()
+        );
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await mediator.CreateStream(null!).ToListAsync());
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await concrete.CreateStream((SomeStreamingRequest)null!).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamRequest_Handler_NonNull_NonRequest()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        object message = new { Id = id };
+        var request = Unsafe.As<object, IStreamRequest<SomeResponse>>(ref message);
+
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            async () => await mediator.CreateStream(message).ToListAsync()
+        );
+        await Assert.ThrowsAsync<InvalidMessageException>(
+            async () => await mediator.CreateStream(request).ToListAsync()
+        );
+    }
+
+    [Fact]
+    public async Task Test_StreamRequest_NonNull_NoHandler()
+    {
+        var (_, mediator) = Fixture.GetMediator();
+        var concrete = (Mediator)mediator;
+
+        var id = Guid.NewGuid();
+
+        var request = new SomeStreamingRequestWithoutHandler(id);
+
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream((object)request).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await mediator.CreateStream(request).ToListAsync()
+        );
+        await Assert.ThrowsAsync<MissingMessageHandlerException>(
+            async () => await concrete.CreateStream(request).ToListAsync()
+        );
     }
 }

--- a/test/Mediator.Tests/TestTypes/SomeCommand.cs
+++ b/test/Mediator.Tests/TestTypes/SomeCommand.cs
@@ -18,3 +18,7 @@ public readonly struct SomeStructCommand : ICommand
 
     public Guid CorrelationId { get; }
 }
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeCommandWithoutHandler(Guid Id) : ICommand;
+#pragma warning restore MSG0005 // MediatorGenerator message warning

--- a/test/Mediator.Tests/TestTypes/SomeQuery.cs
+++ b/test/Mediator.Tests/TestTypes/SomeQuery.cs
@@ -3,3 +3,7 @@ using System;
 namespace Mediator.Tests.TestTypes;
 
 public sealed record SomeQuery(Guid Id) : IQuery<SomeResponse>;
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeQueryWithoutHandler(Guid Id) : IQuery<SomeResponse>;
+#pragma warning restore MSG0005 // MediatorGenerator message warning

--- a/test/Mediator.Tests/TestTypes/SomeRequest.cs
+++ b/test/Mediator.Tests/TestTypes/SomeRequest.cs
@@ -7,3 +7,7 @@ public sealed record SomeRequest(Guid Id) : IRequest<SomeResponse>;
 public sealed record SomeRequestWithoutResponse(Guid Id) : IRequest;
 
 public sealed record SomeRequestReturningByteArray(Guid Id) : IRequest<byte[]>;
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeRequestWithoutHandler(Guid Id) : IRequest;
+#pragma warning restore MSG0005 // MediatorGenerator message warning

--- a/test/Mediator.Tests/TestTypes/SomeStreamingCommand.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingCommand.cs
@@ -29,3 +29,7 @@ public sealed class SomeStreamingCommandHandler : IStreamCommandHandler<SomeStre
         }
     }
 }
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeStreamingCommandWithoutHandler(Guid Id) : IStreamCommand<SomeResponse>;
+#pragma warning restore MSG0005 // MediatorGenerator message warning

--- a/test/Mediator.Tests/TestTypes/SomeStreamingQuery.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingQuery.cs
@@ -29,3 +29,7 @@ public sealed class SomeStreamingQueryHandler : IStreamQueryHandler<SomeStreamin
         }
     }
 }
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeStreamingQueryWithoutHandler(Guid Id) : IStreamQuery<SomeResponse>;
+#pragma warning restore MSG0005 // MediatorGenerator message warning

--- a/test/Mediator.Tests/TestTypes/SomeStreamingRequest.cs
+++ b/test/Mediator.Tests/TestTypes/SomeStreamingRequest.cs
@@ -29,3 +29,7 @@ public sealed class SomeStreamingRequestHandler : IStreamRequestHandler<SomeStre
         }
     }
 }
+
+#pragma warning disable MSG0005 // MediatorGenerator message warning
+public sealed record SomeStreamingRequestWithoutHandler(Guid Id) : IStreamRequest<SomeResponse>;
+#pragma warning restore MSG0005 // MediatorGenerator message warning


### PR DESCRIPTION
Improves the error handling. Handling of requests, queries and commands can throw the following exceptions

* `ArgumentNullException` - the message is `null`
* `MissingMessageHandlerException` - no handler defined
* `InvalidMessageException` - message does not derive from `IMessage`

All methods in the generated Mediator implementation now throw these correctly and XML docs are updated on the implementation class as well as the interfaces in the `Mediator.Abstractions` package.

Notifications have the same behavior except for throwing `MissingMessageHandlerException` (they don't).

I consider this a breaking change so this will go to version 3.0