### PR TITLE
Pre, post processors and exception handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,19 @@ public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : MessageExceptio
     )
     {
         _logger.LogError(exception, "Error handling message of type {messageType}", message.GetType().Name);
+        // Let the exception bubble up by using the base class helper NotHandled:
         return NotHandled;
+        // Or if the exception is properly handled, you can just return your own response,
+        // using the base class helper Handle().
+        // This requires you to know something about TResponse,
+        // so TResponse needs to be constrained to something,
+        // typically with a static abstract member acting as a consructor on an interface or abstract class.
+        return Handled(null!);
     }
 }
 
 // Register as IPipelineBehavior<,> in either case
-services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(MessageValidatorBehaviour<,>))
+services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ErrorLoggingBehaviour<,>))
 ```
 
 ### 3.4. Configuration
@@ -343,6 +350,7 @@ public sealed class PingValidator : IPipelineBehavior<Ping, Pong>
 Add open generic handler to process all or a subset of messages passing through Mediator.
 This handler will log any error that is thrown from message handlers (`IRequest`, `ICommand`, `IQuery`).
 It also publishes a notification allowing notification handlers to react to errors.
+Message pre- and post-processors along with the exception handlers can also constrain the generic type parameters in the same way.
 
 ```csharp
 services.AddMediator();

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/martinothamar/Mediator/Build)](https://github.com/martinothamar/Mediator/actions)<br/>
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/martinothamar/Mediator/build.yml?branch=main)](https://github.com/martinothamar/Mediator/actions)
+[![GitHub](https://img.shields.io/github/license/martinothamar/Mediator?style=flat-square)](https://github.com/martinothamar/Mediator/blob/main/LICENSE)
+[![Downloads](https://img.shields.io/nuget/dt/mediator.abstractions?style=flat-square)](https://www.nuget.org/packages/Mediator.Abstractions/)<br/>
 [![Abstractions NuGet current](https://img.shields.io/nuget/v/Mediator.Abstractions?label=Mediator.Abstractions)](https://www.nuget.org/packages/Mediator.Abstractions)
-[![SourceGenerator NuGet current](https://img.shields.io/nuget/v/Mediator.SourceGenerator?label=Mediator.SourceGenerator)](https://www.nuget.org/packages/Mediator.SourceGenerator)<br/>
+[![SourceGenerator NuGet current](https://img.shields.io/nuget/v/Mediator.SourceGenerator?label=Mediator.SourceGenerator)](https://www.nuget.org/packages/Mediator.SourceGenerator)
 [![Abstractions NuGet prerelease](https://img.shields.io/nuget/vpre/Mediator.Abstractions?label=Mediator.Abstractions)](https://www.nuget.org/packages/Mediator.Abstractions)
 [![SourceGenerator NuGet prerelease](https://img.shields.io/nuget/vpre/Mediator.SourceGenerator?label=Mediator.SourceGenerator)](https://www.nuget.org/packages/Mediator.SourceGenerator)<br/>
 
@@ -34,11 +36,14 @@ See this great video by [@Elfocrash / Nick Chapsas](https://github.com/Elfocrash
 ## Table of Contents
 
 - [Mediator](#mediator)
+  - [Table of Contents](#table-of-contents)
   - [2. Benchmarks](#2-benchmarks)
   - [3. Usage and abstractions](#3-usage-and-abstractions)
     - [3.1. Message types](#31-message-types)
     - [3.2. Handler types](#32-handler-types)
     - [3.3. Pipeline types](#33-pipeline-types)
+      - [3.3.1. Message validation example](#331-message-validation-example)
+      - [3.3.2. Error logging example](#332-error-logging-example)
     - [3.4. Configuration](#34-configuration)
   - [4. Getting started](#4-getting-started)
     - [4.1. Add package](#41-add-package)
@@ -80,12 +85,12 @@ There are two NuGet packages needed to use this library
   * Message types (`IRequest<,>`, `INotification`), handler types (`IRequestHandler<,>`, `INotificationHandler<>`), pipeline types (`IPipelineBehavior`)
 
 You install the source generator package into your edge/outermost project (i.e. ASP.NET Core application, Background worker project),
-and then use the `Mediator` package wherever you define message types and handlers.
+and then use the `Mediator.Abstractions` package wherever you define message types and handlers.
 Standard message handlers are automatically picked up and added to the DI container in the generated `AddMediator` method.
-*Pipeline behaviors need to be added manually.*
+*Pipeline behaviors need to be added manually (including pre/post/exception behaviors).*
 
 For example implementations, see the [/samples](/samples) folder.
-See the [ASP.NET sample](/samples/ASPNET_CleanArchitecture) for a more real world setup.
+See the [ASP.NET Core sample](/samples/ASPNET_CleanArchitecture) for a more real world setup.
 
 ### 3.1. Message types
 
@@ -124,27 +129,103 @@ These types are used in correlation with the message types above.
 
 * `IPipelineBehavior<TMessage, TResponse>`
 * `IStreamPipelineBehavior<TMessage, TResponse>`
+* `MessagePreProcessor<TMessage, TResponse>`
+* `MessagePostProcessor<TMessage, TResponse>`
+* `MessageExceptionHandler<TMessage, TResponse, TException>`
+
+#### 3.3.1. Message validation example
 
 ```csharp
-public sealed class GenericHandler<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
-    where TMessage : IMessage
+// As a normal pipeline behavior
+public sealed class MessageValidatorBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : IValidate
 {
-    public ValueTask<TResponse> Handle(TMessage message, CancellationToken cancellationToken, MessageHandlerDelegate<TMessage, TResponse> next)
+    public ValueTask<TResponse> Handle(
+        TMessage message,
+        CancellationToken cancellationToken,
+        MessageHandlerDelegate<TMessage, TResponse> next
+    )
     {
-        // ...
+        if (!message.IsValid(out var validationError))
+            throw new ValidationException(validationError);
+
         return next(message, cancellationToken);
     }
 }
 
-public sealed class GenericStreamHandler<TMessage, TResponse> : IStreamPipelineBehavior<TMessage, TResponse>
-    where TMessage : IStreamMessage
+// Or as a pre-processor
+public sealed class MessageValidatorBehaviour<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+    where TMessage : IValidate
 {
-    public IAsyncEnumerable<TResponse> Handle(TMessage message, CancellationToken cancellationToken, StreamHandlerDelegate<TMessage, TResponse> next)
+    protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
     {
-        // ...
-        return next(message, cancellationToken);
+        if (!message.IsValid(out var validationError))
+            throw new ValidationException(validationError);
+
+        return default;
     }
 }
+
+// Register as IPipelineBehavior<,> in either case
+services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(MessageValidatorBehaviour<,>))
+```
+
+#### 3.3.2. Error logging example
+
+```csharp
+// As a normal pipeline behavior
+public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : IMessage
+{
+    private readonly ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> _logger;
+
+    public ErrorLoggingBehaviour(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        CancellationToken cancellationToken,
+        MessageHandlerDelegate<TMessage, TResponse> next
+    )
+    {
+        try
+        {
+            return await next(message, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling message of type {messageType}", message.GetType().Name);
+            throw;
+        }
+    }
+}
+
+// Or as an exception handler
+public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+{
+    private readonly ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> _logger;
+
+    public ErrorLoggingBehaviour(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
+        TMessage message,
+        Exception exception,
+        CancellationToken cancellationToken
+    )
+    {
+        _logger.LogError(exception, "Error handling message of type {messageType}", message.GetType().Name);
+        return NotHandled;
+    }
+}
+
+// Register as IPipelineBehavior<,> in either case
+services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(MessageValidatorBehaviour<,>))
 ```
 
 ### 3.4. Configuration

--- a/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/ErrorLoggingBehaviour.cs
+++ b/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/ErrorLoggingBehaviour.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AspNetSample.Application;
 
-public sealed class ErrorLoggingBehaviour2<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
     where TMessage : notnull, IMessage
 {
     private readonly ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> _logger;
 
-    public ErrorLoggingBehaviour2(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
+    public ErrorLoggingBehaviour(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
     {
         _logger = logger;
     }
@@ -21,33 +21,5 @@ public sealed class ErrorLoggingBehaviour2<TMessage, TResponse> : MessageExcepti
     {
         _logger.LogError(exception, "Error handling message of type {messageType}", message.GetType().Name);
         return NotHandled;
-    }
-}
-
-public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
-    where TMessage : IMessage
-{
-    private readonly ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> _logger;
-
-    public ErrorLoggingBehaviour(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
-    {
-        _logger = logger;
-    }
-
-    public async ValueTask<TResponse> Handle(
-        TMessage message,
-        CancellationToken cancellationToken,
-        MessageHandlerDelegate<TMessage, TResponse> next
-    )
-    {
-        try
-        {
-            return await next(message, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error handling message of type {messageType}", message.GetType().Name);
-            throw;
-        }
     }
 }

--- a/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/ErrorLoggingBehaviour.cs
+++ b/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/ErrorLoggingBehaviour.cs
@@ -3,6 +3,27 @@ using Microsoft.Extensions.Logging;
 
 namespace AspNetSample.Application;
 
+public sealed class ErrorLoggingBehaviour2<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+{
+    private readonly ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> _logger;
+
+    public ErrorLoggingBehaviour2(ILogger<ErrorLoggingBehaviour<TMessage, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
+        TMessage message,
+        Exception exception,
+        CancellationToken cancellationToken
+    )
+    {
+        _logger.LogError(exception, "Error handling message of type {messageType}", message.GetType().Name);
+        return NotHandled;
+    }
+}
+
 public sealed class ErrorLoggingBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
     where TMessage : IMessage
 {

--- a/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/MessageValidatorBehaviour.cs
+++ b/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/MessageValidatorBehaviour.cs
@@ -2,7 +2,7 @@ using Mediator;
 
 namespace AspNetSample.Application;
 
-public sealed class MessageValidatorBehaviour2<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+public sealed class MessageValidatorBehaviour<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
     where TMessage : IValidate
 {
     protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
@@ -11,21 +11,5 @@ public sealed class MessageValidatorBehaviour2<TMessage, TResponse> : MessagePre
             throw new ValidationException(validationError);
 
         return default;
-    }
-}
-
-public sealed class MessageValidatorBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
-    where TMessage : IValidate
-{
-    public ValueTask<TResponse> Handle(
-        TMessage message,
-        CancellationToken cancellationToken,
-        MessageHandlerDelegate<TMessage, TResponse> next
-    )
-    {
-        if (!message.IsValid(out var validationError))
-            throw new ValidationException(validationError);
-
-        return next(message, cancellationToken);
     }
 }

--- a/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/MessageValidatorBehaviour.cs
+++ b/samples/ASPNET_CleanArchitecture/AspNetSample.Application/Pipeline/MessageValidatorBehaviour.cs
@@ -2,6 +2,18 @@ using Mediator;
 
 namespace AspNetSample.Application;
 
+public sealed class MessageValidatorBehaviour2<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+    where TMessage : IValidate
+{
+    protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
+    {
+        if (!message.IsValid(out var validationError))
+            throw new ValidationException(validationError);
+
+        return default;
+    }
+}
+
 public sealed class MessageValidatorBehaviour<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
     where TMessage : IValidate
 {

--- a/src/Mediator/Pipeline/MessageExceptionHandler.cs
+++ b/src/Mediator/Pipeline/MessageExceptionHandler.cs
@@ -1,0 +1,36 @@
+namespace Mediator;
+
+public abstract class MessageExceptionHandler<TMessage, TResponse, TException> : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+    where TException : Exception
+{
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        CancellationToken cancellationToken,
+        MessageHandlerDelegate<TMessage, TResponse> next
+    )
+    {
+        try
+        {
+            return await next(message, cancellationToken);
+        }
+        catch (TException exception)
+        {
+            var (handled, response) = await Handle(message, exception, cancellationToken);
+
+            if (!handled)
+                throw;
+
+            return response;
+        }
+    }
+
+    protected abstract ValueTask<(bool Handled, TResponse Response)> Handle(
+        TMessage message,
+        TException exception,
+        CancellationToken cancellationToken
+    );
+}
+
+public abstract class MessageExceptionHandler<TMessage, TResponse>
+    : MessageExceptionHandler<TMessage, TResponse, Exception> where TMessage : notnull, IMessage { }

--- a/src/Mediator/Pipeline/MessageExceptionHandler.cs
+++ b/src/Mediator/Pipeline/MessageExceptionHandler.cs
@@ -1,5 +1,29 @@
 namespace Mediator;
 
+public readonly struct ExceptionHandlingResult<TResponse>
+{
+    internal readonly TResponse _response;
+    internal readonly bool _handled;
+
+    public static readonly ExceptionHandlingResult<TResponse> NotHandled = new ExceptionHandlingResult<TResponse>(
+        false,
+        default!
+    );
+
+    public static ExceptionHandlingResult<TResponse> Handled(TResponse response) =>
+        new ExceptionHandlingResult<TResponse>(true, response);
+
+    private ExceptionHandlingResult(bool handled, TResponse response)
+    {
+        _handled = handled;
+        _response = response;
+    }
+
+    public static implicit operator ValueTask<ExceptionHandlingResult<TResponse>>(
+        ExceptionHandlingResult<TResponse> result
+    ) => new ValueTask<ExceptionHandlingResult<TResponse>>(result);
+}
+
 public abstract class MessageExceptionHandler<TMessage, TResponse, TException> : IPipelineBehavior<TMessage, TResponse>
     where TMessage : notnull, IMessage
     where TException : Exception
@@ -16,20 +40,26 @@ public abstract class MessageExceptionHandler<TMessage, TResponse, TException> :
         }
         catch (TException exception)
         {
-            var (handled, response) = await Handle(message, exception, cancellationToken);
+            var result = await Handle(message, exception, cancellationToken);
 
-            if (!handled)
+            if (!result._handled)
                 throw;
 
-            return response;
+            return result._response;
         }
     }
 
-    protected abstract ValueTask<(bool Handled, TResponse Response)> Handle(
+    protected abstract ValueTask<ExceptionHandlingResult<TResponse>> Handle(
         TMessage message,
         TException exception,
         CancellationToken cancellationToken
     );
+
+    protected static readonly ExceptionHandlingResult<TResponse> NotHandled =
+        ExceptionHandlingResult<TResponse>.NotHandled;
+
+    protected static ExceptionHandlingResult<TResponse> Handled(TResponse response) =>
+        ExceptionHandlingResult<TResponse>.Handled(response);
 }
 
 public abstract class MessageExceptionHandler<TMessage, TResponse>

--- a/src/Mediator/Pipeline/MessagePostProcessor.cs
+++ b/src/Mediator/Pipeline/MessagePostProcessor.cs
@@ -1,0 +1,18 @@
+﻿namespace Mediator;
+
+public abstract class MessagePostProcessor<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+{
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        CancellationToken cancellationToken,
+        MessageHandlerDelegate<TMessage, TResponse> next
+    )
+    {
+        var response = await next(message, cancellationToken);
+        await Handle(message, response, cancellationToken);
+        return response;
+    }
+
+    protected abstract ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken);
+}

--- a/src/Mediator/Pipeline/MessagePreProcessor.cs
+++ b/src/Mediator/Pipeline/MessagePreProcessor.cs
@@ -1,0 +1,31 @@
+﻿namespace Mediator;
+
+public abstract class MessagePreProcessor<TMessage, TResponse> : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+{
+    public ValueTask<TResponse> Handle(
+        TMessage message,
+        CancellationToken cancellationToken,
+        MessageHandlerDelegate<TMessage, TResponse> next
+    )
+    {
+        var task = Handle(message, cancellationToken);
+        if (task.IsCompletedSuccessfully)
+            return next(message, cancellationToken);
+
+        return HandleInternal(task, message, cancellationToken, next);
+
+        static async ValueTask<TResponse> HandleInternal(
+            ValueTask task,
+            TMessage message,
+            CancellationToken cancellationToken,
+            MessageHandlerDelegate<TMessage, TResponse> next
+        )
+        {
+            await task;
+            return await next(message, cancellationToken);
+        }
+    }
+
+    protected abstract ValueTask Handle(TMessage message, CancellationToken cancellationToken);
+}

--- a/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
+++ b/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
@@ -8,6 +8,8 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
+++ b/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
@@ -8,6 +8,8 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,7 +41,7 @@
     <ProjectReference Include="..\..\src\Mediator.SourceGenerator.Roslyn38\Mediator.SourceGenerator.Roslyn38.csproj" OutputItemType="Analyzer" />
     <ProjectReference Include="..\..\src\Mediator\Mediator.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\Mediator.Tests\**\*.cs" Exclude="..\Mediator.Tests\obj\**;..\Mediator.Tests\bin\**;..\Mediator.Tests\Generated\**;..\Mediator.Tests\SingletonLifetimeTests.cs;..\Mediator.Tests\SmokeTests.FastLazy.cs">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/test/Mediator.Tests/Mediator.Tests.csproj
+++ b/test/Mediator.Tests/Mediator.Tests.csproj
@@ -7,9 +7,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <LangVersion>preview</LangVersion>
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
     <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/ConcreteExceptionHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/ConcreteExceptionHandlerTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.ExceptionHandling;
+
+public class ConcreteExceptionHandlerTests
+{
+    [Fact]
+    public async Task Test_ExceptionHandler()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<State>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ExceptionHandler<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<State>();
+        Assert.NotNull(state);
+
+        var response = await mediator.Send(new ErroringRequest(id, 0));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(typeof(NotImplementedException), state?.Exception?.GetType());
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await mediator.Send(new ErroringRequest(id, 1)));
+    }
+
+    public sealed class State
+    {
+        public Exception? Exception { get; set; }
+    }
+
+    private sealed class ExceptionHandler<TMessage, TResponse>
+        : MessageExceptionHandler<TMessage, TResponse, NotImplementedException>
+        where TMessage : notnull, IMessage
+        where TResponse : ICreateable<TResponse>
+    {
+        private readonly State _state;
+
+        public ExceptionHandler(State state) => _state = state;
+
+        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+            TMessage message,
+            NotImplementedException exception,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Exception = exception;
+            var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            return new ValueTask<(bool Handled, TResponse Response)>((true, TResponse.Create(id)));
+        }
+    }
+
+    public interface ICreateable<TResponse> where TResponse : ICreateable<TResponse>
+    {
+        static abstract TResponse Create(Guid id);
+    }
+
+    public sealed record TestResponse(Guid Id) : ICreateable<TestResponse>
+    {
+        public static TestResponse Create(Guid id) => new TestResponse(id);
+    }
+
+    public sealed record ErroringRequest(Guid Id, int N) : IRequest<TestResponse>;
+
+    public sealed class ErroringRequestHandler : IRequestHandler<ErroringRequest, TestResponse>
+    {
+        public ValueTask<TestResponse> Handle(ErroringRequest request, CancellationToken cancellationToken)
+        {
+            if (request.N == 0)
+                throw new NotImplementedException();
+            else
+                throw new ArgumentException();
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/ConcreteExceptionHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/ConcreteExceptionHandlerTests.cs
@@ -44,7 +44,7 @@ public class ConcreteExceptionHandlerTests
 
         public ExceptionHandler(State state) => _state = state;
 
-        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+        protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
             TMessage message,
             NotImplementedException exception,
             CancellationToken cancellationToken
@@ -52,7 +52,7 @@ public class ConcreteExceptionHandlerTests
         {
             _state.Exception = exception;
             var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
-            return new ValueTask<(bool Handled, TResponse Response)>((true, TResponse.Create(id)));
+            return Handled(TResponse.Create(id));
         }
     }
 

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/GeneralHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/GeneralHandlerTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.ExceptionHandling;
+
+public class GeneralHandlerTests
+{
+    [Fact]
+    public async Task Test_ExceptionHandler()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<State>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ExceptionHandler<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<State>();
+        Assert.NotNull(state);
+
+        var response = await mediator.Send(new ErroringRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(typeof(NotImplementedException), state?.Exception?.GetType());
+    }
+
+    private sealed class State
+    {
+        public Exception? Exception { get; set; }
+    }
+
+    private sealed class ExceptionHandler<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+        where TResponse : ICreateable<TResponse>
+    {
+        private readonly State _state;
+
+        public ExceptionHandler(State state) => _state = state;
+
+        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+            TMessage message,
+            Exception exception,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Exception = exception;
+            var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            return new ValueTask<(bool Handled, TResponse Response)>((true, TResponse.Create(id)));
+        }
+    }
+
+    public interface ICreateable<TResponse> where TResponse : ICreateable<TResponse>
+    {
+        static abstract TResponse Create(Guid id);
+    }
+
+    public sealed record TestResponse(Guid Id) : ICreateable<TestResponse>
+    {
+        public static TestResponse Create(Guid id) => new TestResponse(id);
+    }
+
+    public sealed record ErroringRequest(Guid Id) : IRequest<TestResponse>;
+
+    public sealed class ErroringRequestHandler : IRequestHandler<ErroringRequest, TestResponse>
+    {
+        public ValueTask<TestResponse> Handle(ErroringRequest request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/GeneralHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/GeneralHandlerTests.cs
@@ -41,7 +41,7 @@ public class GeneralHandlerTests
 
         public ExceptionHandler(State state) => _state = state;
 
-        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+        protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
             TMessage message,
             Exception exception,
             CancellationToken cancellationToken
@@ -49,7 +49,7 @@ public class GeneralHandlerTests
         {
             _state.Exception = exception;
             var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
-            return new ValueTask<(bool Handled, TResponse Response)>((true, TResponse.Create(id)));
+            return Handled(TResponse.Create(id));
         }
     }
 

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/MultipleHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/MultipleHandlerTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.ExceptionHandling;
+
+public class MultipleHandlerTests
+{
+    [Fact]
+    public async Task Test_ExceptionHandler()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<State>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ExceptionHandler<,>));
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ExceptionHandler2<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<State>();
+        Assert.NotNull(state);
+        state!.Reset();
+
+        var response = await mediator.Send(new ErroringRequest(id, 1));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(typeof(NotImplementedException), state.Handler1Exception?.GetType());
+        Assert.Null(state.Handler2Exception);
+        state.Reset();
+
+        response = await mediator.Send(new ErroringRequest(id, 2));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(typeof(NotImplementedException), state.Handler2Exception?.GetType());
+        Assert.Null(state.Handler1Exception);
+        state.Reset();
+
+        await Assert.ThrowsAsync<NotImplementedException>(async () => await mediator.Send(new ErroringRequest(id, -1)));
+        Assert.True(state.Handler1Timestamp > state.Handler2Timestamp);
+        state.Reset();
+
+        await Assert.ThrowsAsync<NotImplementedException>(async () => await mediator.Send(new ErroringRequest(id, -1)));
+        Assert.True(state.Handler1Timestamp > state.Handler2Timestamp);
+        state.Reset();
+    }
+
+    private sealed class State
+    {
+        public Exception? Handler1Exception { get; set; }
+        public long Handler1Timestamp { get; set; }
+
+        public Exception? Handler2Exception { get; set; }
+        public long Handler2Timestamp { get; set; }
+
+        public void Reset()
+        {
+            Handler1Exception = null;
+            Handler2Exception = null;
+            Handler1Timestamp = default;
+            Handler2Timestamp = default;
+        }
+    }
+
+    private sealed class ExceptionHandler<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+        where TResponse : ICreateable<TResponse>
+    {
+        private readonly State _state;
+
+        public ExceptionHandler(State state) => _state = state;
+
+        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+            TMessage message,
+            Exception exception,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Handler1Timestamp = Stopwatch.GetTimestamp();
+            var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            var n = (int)typeof(TMessage).GetProperty("N")!.GetValue(message)!;
+            var handled = n is 1 or 3;
+            if (handled)
+                _state.Handler1Exception = exception;
+            return new ValueTask<(bool Handled, TResponse Response)>((handled, TResponse.Create(id)));
+        }
+    }
+
+    private sealed class ExceptionHandler2<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+        where TResponse : ICreateable<TResponse>
+    {
+        private readonly State _state;
+
+        public ExceptionHandler2(State state) => _state = state;
+
+        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+            TMessage message,
+            Exception exception,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Handler2Timestamp = Stopwatch.GetTimestamp();
+            var id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            var n = (int)typeof(TMessage).GetProperty("N")!.GetValue(message)!;
+            var handled = n is 2 or 3 ? true : false;
+            if (handled)
+                _state.Handler2Exception = exception;
+            return new ValueTask<(bool Handled, TResponse Response)>((handled, TResponse.Create(id)));
+        }
+    }
+
+    public interface ICreateable<TResponse> where TResponse : ICreateable<TResponse>
+    {
+        static abstract TResponse Create(Guid id);
+    }
+
+    public sealed record TestResponse(Guid Id) : ICreateable<TestResponse>
+    {
+        public static TestResponse Create(Guid id) => new TestResponse(id);
+    }
+
+    public sealed record ErroringRequest(Guid Id, int N) : IRequest<TestResponse>;
+
+    public sealed class ErroringRequestHandler : IRequestHandler<ErroringRequest, TestResponse>
+    {
+        public ValueTask<TestResponse> Handle(ErroringRequest request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/MultipleHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/MultipleHandlerTests.cs
@@ -72,7 +72,7 @@ public class MultipleHandlerTests
 
         public ExceptionHandler(State state) => _state = state;
 
-        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+        protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
             TMessage message,
             Exception exception,
             CancellationToken cancellationToken
@@ -83,8 +83,14 @@ public class MultipleHandlerTests
             var n = (int)typeof(TMessage).GetProperty("N")!.GetValue(message)!;
             var handled = n is 1 or 3;
             if (handled)
+            {
                 _state.Handler1Exception = exception;
-            return new ValueTask<(bool Handled, TResponse Response)>((handled, TResponse.Create(id)));
+                return Handled(TResponse.Create(id));
+            }
+            else
+            {
+                return NotHandled;
+            }
         }
     }
 
@@ -96,7 +102,7 @@ public class MultipleHandlerTests
 
         public ExceptionHandler2(State state) => _state = state;
 
-        protected override ValueTask<(bool Handled, TResponse Response)> Handle(
+        protected override ValueTask<ExceptionHandlingResult<TResponse>> Handle(
             TMessage message,
             Exception exception,
             CancellationToken cancellationToken
@@ -107,8 +113,14 @@ public class MultipleHandlerTests
             var n = (int)typeof(TMessage).GetProperty("N")!.GetValue(message)!;
             var handled = n is 2 or 3 ? true : false;
             if (handled)
+            {
                 _state.Handler2Exception = exception;
-            return new ValueTask<(bool Handled, TResponse Response)>((handled, TResponse.Create(id)));
+                return Handled(TResponse.Create(id));
+            }
+            else
+            {
+                return NotHandled;
+            }
         }
     }
 

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/OnlyLoggingHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/OnlyLoggingHandlerTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.ExceptionHandling;
+
+public class OnlyLoggingHandlerTests
+{
+    [Fact]
+    public async Task Test_ExceptionHandler()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<State>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ExceptionHandler<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<State>();
+        Assert.NotNull(state);
+
+        await Assert.ThrowsAsync<NotImplementedException>(async () => await mediator.Send(new ErroringRequest(id)));
+        Assert.Equal(typeof(NotImplementedException), state?.Exception?.GetType());
+    }
+
+    private sealed class State
+    {
+        public Exception? Exception { get; set; }
+    }
+
+    private sealed class ExceptionHandler<TMessage, TResponse> : MessageExceptionHandler<TMessage, TResponse?>
+        where TMessage : notnull, IMessage
+    {
+        private readonly State _state;
+
+        public ExceptionHandler(State state) => _state = state;
+
+        protected override ValueTask<(bool Handled, TResponse? Response)> Handle(
+            TMessage message,
+            Exception exception,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Exception = exception;
+            return new ValueTask<(bool Handled, TResponse? Response)>((false, default));
+        }
+    }
+
+    public sealed record TestResponse(Guid Id);
+
+    public sealed record ErroringRequest(Guid Id) : IRequest<TestResponse>;
+
+    public sealed class ErroringRequestHandler : IRequestHandler<ErroringRequest, TestResponse>
+    {
+        public ValueTask<TestResponse> Handle(ErroringRequest request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/ExceptionHandling/OnlyLoggingHandlerTests.cs
+++ b/test/Mediator.Tests/Pipeline/ExceptionHandling/OnlyLoggingHandlerTests.cs
@@ -39,14 +39,14 @@ public class OnlyLoggingHandlerTests
 
         public ExceptionHandler(State state) => _state = state;
 
-        protected override ValueTask<(bool Handled, TResponse? Response)> Handle(
+        protected override ValueTask<ExceptionHandlingResult<TResponse?>> Handle(
             TMessage message,
             Exception exception,
             CancellationToken cancellationToken
         )
         {
             _state.Exception = exception;
-            return new ValueTask<(bool Handled, TResponse? Response)>((false, default));
+            return NotHandled;
         }
     }
 

--- a/test/Mediator.Tests/Pipeline/PostProcessing/BasicTests.cs
+++ b/test/Mediator.Tests/Pipeline/PostProcessing/BasicTests.cs
@@ -1,0 +1,75 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PostProcessing;
+
+public class BasicTests
+{
+    [Fact]
+    public async Task Test_PostProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PostProcessingState>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePostProcessor<,>));
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePostProcessor2<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PostProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(queryId, state!.Id);
+        Assert.Equal(4, state.Calls);
+    }
+
+    private sealed class PostProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePostProcessor<TMessage, TResponse> : MessagePostProcessor<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePostProcessor2<TMessage, TResponse> : MessagePostProcessor<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor2(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/PostProcessing/ConcreteTests.cs
+++ b/test/Mediator.Tests/Pipeline/PostProcessing/ConcreteTests.cs
@@ -1,0 +1,81 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PostProcessing;
+
+public class ConcreteTests
+{
+    [Fact]
+    public async Task Test_PostProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PostProcessingState>();
+                services.AddSingleton<IPipelineBehavior<SomeRequest, SomeResponse>, TestMessagePostProcessor>();
+                services.AddSingleton<IPipelineBehavior<SomeRequest, SomeResponse>, TestMessagePostProcessor2>();
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PostProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+    }
+
+    private sealed class PostProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePostProcessor : MessagePostProcessor<SomeRequest, SomeResponse>
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(
+            SomeRequest message,
+            SomeResponse response,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Id = message.Id;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePostProcessor2 : MessagePostProcessor<SomeRequest, SomeResponse>
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor2(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(
+            SomeRequest message,
+            SomeResponse response,
+            CancellationToken cancellationToken
+        )
+        {
+            _state.Id = message.Id;
+            _state.Calls++;
+            return default;
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/PostProcessing/GenericConstrainedTests.cs
+++ b/test/Mediator.Tests/Pipeline/PostProcessing/GenericConstrainedTests.cs
@@ -1,0 +1,80 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PostProcessing;
+
+public class GenericConstrainedTests
+{
+    [Fact]
+    public async Task Test_PostProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PostProcessingState>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePostProcessor<,>));
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePostProcessor2<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PostProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(4, state.Calls);
+    }
+
+    private sealed class PostProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePostProcessor<TMessage, TResponse> : MessagePostProcessor<TMessage, TResponse>
+        where TMessage : notnull, IRequest<TResponse>
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePostProcessor2<TMessage, TResponse> : MessagePostProcessor<TMessage, TResponse>
+        where TMessage : notnull, IRequest<TResponse>
+    {
+        private readonly PostProcessingState _state;
+
+        public TestMessagePostProcessor2(PostProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, TResponse response, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/PreProcessing/BasicTests.cs
+++ b/test/Mediator.Tests/Pipeline/PreProcessing/BasicTests.cs
@@ -1,0 +1,75 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PreProcessing;
+
+public class BasicTests
+{
+    [Fact]
+    public async Task Test_PreProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PreProcessingState>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePreProcessor<,>));
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePreProcessor2<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PreProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(queryId, state!.Id);
+        Assert.Equal(4, state.Calls);
+    }
+
+    private sealed class PreProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePreProcessor<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePreProcessor2<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+        where TMessage : notnull, IMessage
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor2(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/PreProcessing/ConcreteTests.cs
+++ b/test/Mediator.Tests/Pipeline/PreProcessing/ConcreteTests.cs
@@ -1,0 +1,73 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PreProcessing;
+
+public class ConcreteTests
+{
+    [Fact]
+    public async Task Test_PreProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PreProcessingState>();
+                services.AddSingleton<IPipelineBehavior<SomeRequest, SomeResponse>, TestMessagePreProcessor>();
+                services.AddSingleton<IPipelineBehavior<SomeRequest, SomeResponse>, TestMessagePreProcessor2>();
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PreProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+    }
+
+    private sealed class PreProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePreProcessor : MessagePreProcessor<SomeRequest, SomeResponse>
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(SomeRequest message, CancellationToken cancellationToken)
+        {
+            _state.Id = message.Id;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePreProcessor2 : MessagePreProcessor<SomeRequest, SomeResponse>
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor2(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(SomeRequest message, CancellationToken cancellationToken)
+        {
+            _state.Id = message.Id;
+            _state.Calls++;
+            return default;
+        }
+    }
+}

--- a/test/Mediator.Tests/Pipeline/PreProcessing/GenericConstrainedTests.cs
+++ b/test/Mediator.Tests/Pipeline/PreProcessing/GenericConstrainedTests.cs
@@ -1,0 +1,80 @@
+using Mediator.Tests.TestTypes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mediator.Tests.Pipeline.PreProcessing;
+
+public class GenericConstrainedTests
+{
+    [Fact]
+    public async Task Test_PreProcessor()
+    {
+        var (sp, mediator) = Fixture.GetMediator(
+            services =>
+            {
+                services.AddSingleton<PreProcessingState>();
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePreProcessor<,>));
+                services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(TestMessagePreProcessor2<,>));
+            }
+        );
+
+        var id = Guid.NewGuid();
+        var queryId = Guid.NewGuid();
+
+        var state = sp.GetRequiredService<PreProcessingState>();
+
+        Assert.NotNull(state);
+        var response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeQuery(queryId));
+        Assert.Equal(queryId, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(2, state.Calls);
+
+        response = await mediator.Send(new SomeRequest(id));
+        Assert.Equal(id, response.Id);
+        Assert.Equal(id, state!.Id);
+        Assert.Equal(4, state.Calls);
+    }
+
+    private sealed class PreProcessingState
+    {
+        public Guid Id;
+        public int Calls;
+    }
+
+    private sealed class TestMessagePreProcessor<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+        where TMessage : notnull, IRequest<TResponse>
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+
+    private sealed class TestMessagePreProcessor2<TMessage, TResponse> : MessagePreProcessor<TMessage, TResponse>
+        where TMessage : notnull, IRequest<TResponse>
+    {
+        private readonly PreProcessingState _state;
+
+        public TestMessagePreProcessor2(PreProcessingState state) => _state = state;
+
+        protected override ValueTask Handle(TMessage message, CancellationToken cancellationToken)
+        {
+            _state.Id = (Guid)typeof(TMessage).GetProperty("Id")!.GetValue(message)!;
+            _state.Calls++;
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
Proposed implementation of pre and post message processors and exception handlers.

The API is not quite the same as in MediatR. Instead of separate interfaces, there are abstract classes which are still registered as `IPipelineBehavior<,>` in the DI container. This allows for better performance for the cases where these abstractions aren't needed (perf cost is only introduced when they are actually added to the container).

Will consider adding benchmarks as well, but this implementation should be more lightweight than the MediatR equivalent, and will be zero cost for non-use.

Solves #6 