### PR TITLE
Make sure transient handlers are disposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+Generated/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator.Implementation/resources/Mediator.sbn-cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public static IServiceCollection AddMediator(this IServiceCollection services, global::System.Action<global::Mediator.MediatorOptions> options)
         {
-            {{~ if ServiceLifetimeIsScoped ~}}
+            {{~ if ServiceLifetimeIsScoped || ServiceLifetimeIsTransient ~}}
             services.Add(new SD(typeof(global::{{ MediatorNamespace }}.Mediator), typeof(global::{{ MediatorNamespace }}.Mediator), {{ ServiceLifetime }}));
             services.TryAdd(new SD(typeof(global::Mediator.IMediator), sp => sp.GetRequiredService<global::{{ MediatorNamespace }}.Mediator>(), {{ ServiceLifetime }}));
             services.TryAdd(new SD(typeof(global::Mediator.ISender), sp => sp.GetRequiredService<global::{{ MediatorNamespace }}.Mediator>(), {{ ServiceLifetime }}));
@@ -189,6 +189,7 @@ namespace {{ MediatorNamespace }}
                  ? (s => ((object[])s).Length) : (s => s.Count());
         }
         
+        {{~ if ServiceLifetimeIsSingleton ~}}
         {{ if IsTestRun }}internal{{ else }}private{{ end }} struct FastLazyValue<T>
             where T : struct
         {
@@ -289,6 +290,7 @@ namespace {{ MediatorNamespace }}
                 _value = default;
             }
         }
+        {{~ end ~}}
 
         {{ if IsTestRun }}internal{{ else }}private{{ end }} readonly struct DICache
         {

--- a/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
+++ b/test/Mediator.Tests.ScopedLifetime/Mediator.Tests.ScopedLifetime.csproj
@@ -6,7 +6,14 @@
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <!--<ReportAnalyzer>true</ReportAnalyzer>-->
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+    <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
@@ -34,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Mediator.Tests\**\*.cs" Exclude="..\Mediator.Tests\obj\**;..\Mediator.Tests\bin\**;..\Mediator.Tests\SingletonLifetimeTests.cs;..\Mediator.Tests\SmokeTests.FastLazy.cs">
+    <Compile Include="..\Mediator.Tests\**\*.cs" Exclude="..\Mediator.Tests\obj\**;..\Mediator.Tests\bin\**;..\Mediator.Tests\Generated\**;..\Mediator.Tests\SingletonLifetimeTests.cs;..\Mediator.Tests\SmokeTests.FastLazy.cs">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>

--- a/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
+++ b/test/Mediator.Tests.TransientLifetime/Mediator.Tests.TransientLifetime.csproj
@@ -6,7 +6,14 @@
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <!--<ReportAnalyzer>true</ReportAnalyzer>-->
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+    <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
@@ -34,7 +41,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Include="..\Mediator.Tests\**\*.cs" Exclude="..\Mediator.Tests\obj\**;..\Mediator.Tests\bin\**;..\Mediator.Tests\SingletonLifetimeTests.cs;..\Mediator.Tests\SmokeTests.FastLazy.cs">
+    <Compile Include="..\Mediator.Tests\**\*.cs" Exclude="..\Mediator.Tests\obj\**;..\Mediator.Tests\bin\**;..\Mediator.Tests\Generated\**;..\Mediator.Tests\SingletonLifetimeTests.cs;..\Mediator.Tests\SmokeTests.FastLazy.cs">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>

--- a/test/Mediator.Tests.TransientLifetime/TransientLifetimeTests.cs
+++ b/test/Mediator.Tests.TransientLifetime/TransientLifetimeTests.cs
@@ -1,5 +1,10 @@
 using Mediator.Tests.TestTypes;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Mediator.Tests.TransientLifetime;
 
@@ -12,15 +17,105 @@ public sealed class TransientLifetimeTests
     }
 
     [Fact]
-    public void Test_Returns_Different_Instance_Every_Time()
+    public async Task Test_Returns_Different_Handler_Instance_Every_Time()
     {
+        using var _ = await TransientTestRequestHandler.LeaseForTesting();
+
         var (sp, _) = Fixture.GetMediator();
 
-        var handler1 = sp.GetRequiredService<SomeRequestHandler>();
-        var handler2 = sp.GetRequiredService<SomeRequestHandler>();
+        var handler1 = sp.GetRequiredService<TransientTestRequestHandler>();
+        var handler2 = sp.GetRequiredService<TransientTestRequestHandler>();
 
         Assert.NotNull(handler1);
         Assert.NotNull(handler2);
         Assert.NotEqual(handler1, handler2);
+    }
+
+    [Fact]
+    public async Task Test_Disposes_Handler_Correctly_In_Scope()
+    {
+        using var _ = await TransientTestRequestHandler.LeaseForTesting();
+
+        var services = new ServiceCollection();
+
+        services.AddMediator();
+
+        await using (var sp = services.BuildServiceProvider(validateScopes: true))
+        {
+            await using (var scope = sp.CreateAsyncScope())
+            {
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+
+                Assert.All(TransientTestRequestHandler.CreatedHandlers, h => Assert.False(h.Disposed));
+            }
+
+            Assert.All(TransientTestRequestHandler.CreatedHandlers, h => Assert.True(h.Disposed));
+
+            {
+                var mediator = sp.GetRequiredService<IMediator>();
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+                await mediator.Send(new TransientTest(Guid.NewGuid()));
+            }
+        }
+
+        Assert.All(TransientTestRequestHandler.CreatedHandlers, h => Assert.True(h.Disposed));
+    }
+
+    [Fact]
+    public async Task Test_Disposes_Handler_Correctly_Root_Scope()
+    {
+        using var _ = await TransientTestRequestHandler.LeaseForTesting();
+
+        var services = new ServiceCollection();
+
+        services.AddMediator();
+
+        await using (var sp = services.BuildServiceProvider(validateScopes: true))
+        {
+            var mediator = sp.GetRequiredService<IMediator>();
+
+            await mediator.Send(new TransientTest(Guid.NewGuid()));
+            await mediator.Send(new TransientTest(Guid.NewGuid()));
+            await mediator.Send(new TransientTest(Guid.NewGuid()));
+
+            Assert.All(TransientTestRequestHandler.CreatedHandlers, h => Assert.False(h.Disposed));
+        }
+
+        Assert.All(TransientTestRequestHandler.CreatedHandlers, h => Assert.True(h.Disposed));
+    }
+}
+
+public sealed record TransientTest(Guid Id) : IRequest<SomeResponse>;
+
+public sealed class TransientTestRequestHandler : IRequestHandler<TransientTest, SomeResponse>, IDisposable
+{
+    private static readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+
+    public bool Disposed { get; private set; }
+
+    public static readonly ConcurrentBag<TransientTestRequestHandler> CreatedHandlers = new();
+
+    public TransientTestRequestHandler() => CreatedHandlers.Add(this);
+
+    public ValueTask<SomeResponse> Handle(TransientTest request, CancellationToken cancellationToken) =>
+        new ValueTask<SomeResponse>(new SomeResponse(request.Id));
+
+    public void Dispose() => Disposed = true;
+
+    public static async ValueTask<IDisposable> LeaseForTesting()
+    {
+        await _lock.WaitAsync();
+        CreatedHandlers.Clear();
+        return new Lease();
+    }
+
+    private sealed record Lease() : IDisposable
+    {
+        public void Dispose() => _lock.Release();
     }
 }

--- a/test/Mediator.Tests/Mediator.Tests.csproj
+++ b/test/Mediator.Tests/Mediator.Tests.csproj
@@ -6,8 +6,14 @@
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <!--<ReportAnalyzer>true</ReportAnalyzer>-->
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+    <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />

--- a/test/Mediator.Tests/TestTypes/SomeRequestHandler.cs
+++ b/test/Mediator.Tests/TestTypes/SomeRequestHandler.cs
@@ -5,10 +5,14 @@ using System.Threading.Tasks;
 
 namespace Mediator.Tests.TestTypes;
 
-public sealed class SomeRequestHandler : IRequestHandler<SomeRequest, SomeResponse>
+public sealed class SomeRequestHandler : IRequestHandler<SomeRequest, SomeResponse>, IDisposable
 {
+    public bool Disposed { get; private set; }
+
     public ValueTask<SomeResponse> Handle(SomeRequest request, CancellationToken cancellationToken) =>
         new ValueTask<SomeResponse>(new SomeResponse(request.Id));
+
+    public void Dispose() => Disposed = true;
 }
 
 public sealed class SomeRequestWithoutResponseHandler : IRequestHandler<SomeRequestWithoutResponse>


### PR DESCRIPTION
Fixes #69 and #70 

There was an "optimization" in place where the `Mediator` instance was registered as singleton even when transient lifetime was configured. When that happens, the `IServiceProvider` that `Mediator` instance activates services from is the root service provider (root scope), which means that these transient services won't be disposed until the  container itself is disposed. This is unexpected. 

This makes `Mediator` also register as transient for transient configuration, so that it captures the `IServiceProvider` of the closest enclosing scope. This should lead to the expected behavior and matches what MediatR 