### PR TITLE
Fix for the source generator to process projects that do not directly use any of the types from Mediator.Abstractions

### DIFF
--- a/Mediator.sln
+++ b/Mediator.sln
@@ -90,6 +90,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Samples.SourceGene
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mediator.Benchmarks.Large", "benchmarks\Mediator.Benchmarks.Large\Mediator.Benchmarks.Large.csproj", "{19078764-4D01-403D-9806-7842AF257FFF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ASPNET_Core_Indirect", "ASPNET_Core_Indirect", "{BC759BA5-C064-460E-ACB0-9B2DA12B9284}"
+	ProjectSection(SolutionItems) = preProject
+		samples\ASPNET_Core_Indirect\README.md = samples\ASPNET_Core_Indirect\README.md
+		samples\ASPNET_Core_Indirect\get-weather-forecast.http = samples\ASPNET_Core_Indirect\get-weather-forecast.http
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreIndirect.BaseClasses", "samples\ASPNET_Core_Indirect\AspNetCoreIndirect.BaseClasses\AspNetCoreIndirect.BaseClasses.csproj", "{EBB07938-94A7-4349-9D0F-F2A6088EB42E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreIndirect.Application", "samples\ASPNET_Core_Indirect\AspNetCoreIndirect.Application\AspNetCoreIndirect.Application.csproj", "{DB9A7862-14B1-4DAC-878C-D6B02038F068}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreIndirect.Implementations", "samples\ASPNET_Core_Indirect\AspNetCoreIndirect.Implementations\AspNetCoreIndirect.Implementations.csproj", "{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -400,6 +412,42 @@ Global
 		{19078764-4D01-403D-9806-7842AF257FFF}.Release|x64.Build.0 = Release|Any CPU
 		{19078764-4D01-403D-9806-7842AF257FFF}.Release|x86.ActiveCfg = Release|Any CPU
 		{19078764-4D01-403D-9806-7842AF257FFF}.Release|x86.Build.0 = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|x64.Build.0 = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Debug|x86.Build.0 = Debug|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|x64.ActiveCfg = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|x64.Build.0 = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|x86.ActiveCfg = Release|Any CPU
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E}.Release|x86.Build.0 = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|x64.Build.0 = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|x64.ActiveCfg = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|x64.Build.0 = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068}.Release|x86.Build.0 = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|x64.Build.0 = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -431,6 +479,10 @@ Global
 		{32DC3B96-7E6E-40B0-AA12-40656B2D0381} = {ED1809FC-733B-4D9E-8FEE-70D3BB0BBD84}
 		{8625B7F2-F974-47E7-ABF1-C75AB9C305B2} = {ED1809FC-733B-4D9E-8FEE-70D3BB0BBD84}
 		{19078764-4D01-403D-9806-7842AF257FFF} = {0F5E1C71-66E0-4285-B861-184E5B6C841A}
+		{BC759BA5-C064-460E-ACB0-9B2DA12B9284} = {D3569CDD-7E19-429E-B9AD-75CC05F6C4AA}
+		{EBB07938-94A7-4349-9D0F-F2A6088EB42E} = {BC759BA5-C064-460E-ACB0-9B2DA12B9284}
+		{DB9A7862-14B1-4DAC-878C-D6B02038F068} = {BC759BA5-C064-460E-ACB0-9B2DA12B9284}
+		{7F7DB4D8-3D94-4648-99FA-E7E06A913FCD} = {BC759BA5-C064-460E-ACB0-9B2DA12B9284}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D45B5457-4190-49B6-BF89-7FA5F4C8ABE2}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/AspNetCoreIndirect.Application.csproj
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/AspNetCoreIndirect.Application.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Mediator\Mediator.csproj" />
+    <ProjectReference Include="..\..\..\src\Mediator.SourceGenerator.Implementation\Mediator.SourceGenerator.Implementation.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\..\src\Mediator.SourceGenerator.Roslyn38\Mediator.SourceGenerator.Roslyn38.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\AspNetCoreIndirect.Implementations\AspNetCoreIndirect.Implementations.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/Program.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/Program.cs
@@ -1,0 +1,28 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddMediator();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/Properties/launchSettings.json
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "profiles": {
+    "AspNetCoreIndirect.Application": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/appsettings.Development.json
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/appsettings.json
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Application/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationController.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationController.cs
@@ -1,0 +1,39 @@
+using Mediator;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreIndirect.BaseClasses;
+
+[ApiController]
+public abstract class ApplicationController : ControllerBase
+{
+    /// <summary>
+    /// Send request through Mediator and convert result to IActionResult.
+    /// </summary>
+    /// <param name="request">request to process.</param>
+    /// <typeparam name="TRequest">type of the request.</typeparam>
+    /// <typeparam name="TResponse">type of the response.</typeparam>
+    /// <returns>Action result.</returns>
+    protected async Task<IActionResult> ProcessAsync<TRequest, TResponse>(TRequest request)
+        where TRequest : IRequest<TResponse>
+    {
+        try
+        {
+            var mediator = HttpContext.RequestServices.GetRequiredService<IMediator>();
+
+            var result = await mediator.Send(request, HttpContext.RequestAborted);
+
+            if (typeof(TResponse) == typeof(Unit))
+            {
+                return NoContent();
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return new ObjectResult(new { ex.Message }) { StatusCode = StatusCodes.Status500InternalServerError };
+        }
+    }
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationHandler.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationHandler.cs
@@ -1,0 +1,15 @@
+using Mediator;
+
+namespace AspNetCoreIndirect.BaseClasses;
+
+public abstract class ApplicationHandler<TRequest, TResponse> : IRequestHandler<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    public ValueTask<TResponse> Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        // For the sake of simplicity we'll just return downstream implementation
+        return ProcessRequest(request, cancellationToken);
+    }
+
+    protected abstract ValueTask<TResponse> ProcessRequest(TRequest request, CancellationToken cancellationToken);
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationRequest.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/ApplicationRequest.cs
@@ -1,0 +1,5 @@
+﻿using Mediator;
+
+namespace AspNetCoreIndirect.BaseClasses;
+
+public abstract record ApplicationRequest<TResponse> : IRequest<TResponse>;

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/AspNetCoreIndirect.BaseClasses.csproj
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.BaseClasses/AspNetCoreIndirect.BaseClasses.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Mediator\Mediator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/AspNetCoreIndirect.Implementations.csproj
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/AspNetCoreIndirect.Implementations.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspNetCoreIndirect.BaseClasses\AspNetCoreIndirect.BaseClasses.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/GetWeatherForecast.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/GetWeatherForecast.cs
@@ -1,0 +1,5 @@
+using AspNetCoreIndirect.BaseClasses;
+
+namespace AspNetCoreIndirect.Application;
+
+public record GetWeatherForecast(int Count = 5) : ApplicationRequest<IReadOnlyList<WeatherForecast>>;

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/GetWeatherForecastHandler.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/GetWeatherForecastHandler.cs
@@ -1,0 +1,41 @@
+using AspNetCoreIndirect.BaseClasses;
+
+namespace AspNetCoreIndirect.Application.Controllers;
+
+public class GetWeatherForecastHandler : ApplicationHandler<GetWeatherForecast, IReadOnlyList<WeatherForecast>>
+{
+    private static readonly string[] _summaries =
+    {
+        "Freezing",
+        "Bracing",
+        "Chilly",
+        "Cool",
+        "Mild",
+        "Warm",
+        "Balmy",
+        "Hot",
+        "Sweltering",
+        "Scorching"
+    };
+
+    protected override ValueTask<IReadOnlyList<WeatherForecast>> ProcessRequest(
+        GetWeatherForecast request,
+        CancellationToken cancellationToken
+    )
+    {
+        IReadOnlyList<WeatherForecast> result = Enumerable
+            .Range(1, request.Count)
+            .Select(
+                index =>
+                    new WeatherForecast
+                    {
+                        Date = DateTime.Now.AddDays(index),
+                        TemperatureC = Random.Shared.Next(-20, 55),
+                        Summary = _summaries[Random.Shared.Next(_summaries.Length)]
+                    }
+            )
+            .ToArray();
+
+        return ValueTask.FromResult(result);
+    }
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/WeatherForecast.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace AspNetCoreIndirect.Application;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/WeatherForecastController.cs
+++ b/samples/ASPNET_Core_Indirect/AspNetCoreIndirect.Implementations/WeatherForecastController.cs
@@ -1,0 +1,12 @@
+using AspNetCoreIndirect.BaseClasses;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCoreIndirect.Application.Controllers;
+
+[Route("[controller]")]
+public class WeatherForecastController : ApplicationController
+{
+    [HttpGet]
+    public Task<IActionResult> Get([FromQuery] GetWeatherForecast request) =>
+        ProcessAsync<GetWeatherForecast, IReadOnlyList<WeatherForecast>>(request);
+}

--- a/samples/ASPNET_Core_Indirect/README.md
+++ b/samples/ASPNET_Core_Indirect/README.md
@@ -1,8 +1,9 @@
 ## Scenario with the indirect reference of the Mediator.Abstraction
 
-This example has been created to show the problem in the Source Generator that ignores project
-if they are not directly using any of the types from `Mediator.Abstraction` package,
-but rather include it indirectly through other projects.
+This example has been created to demonstrate the indirect `Mediator.Abstraction` usage approach and
+to perform a regression testing after the source generator analyzer fix.
+Source generator was ignoring projects if they are not directly using any of the types from `Mediator.Abstraction` package,
+but rather include them indirectly through other projects.
 
 `AspNetCoreIndirect.BaseClasses` contains the base classes that are used by the `AspNetCoreIndirect.Implementations`
 project, that provides the implementations of controllers and handlers. `AspNetCoreIndirect.Application` is the entry point
@@ -22,14 +23,43 @@ You
 ```http
 GET http://localhost:5000/WeatherForecast
 
-HTTP/1.1 500 Internal Server Error
+HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
-Date: Sat, 14 Jan 2023 15:16:08 GMT
+Date: Sat, 14 Jan 2023 16:10:38 GMT
 Server: Kestrel
 Transfer-Encoding: chunked
 
-{
-  "message": "No handler registered for message type: AspNetCoreIndirect.Application.GetWeatherForecast"
-}
+[
+  {
+    "date": "2023-01-15T19:10:38.959973+03:00",
+    "temperatureC": 33,
+    "temperatureF": 91,
+    "summary": "Warm"
+  },
+  {
+    "date": "2023-01-16T19:10:38.978643+03:00",
+    "temperatureC": 7,
+    "temperatureF": 44,
+    "summary": "Freezing"
+  },
+  {
+    "date": "2023-01-17T19:10:38.978647+03:00",
+    "temperatureC": 11,
+    "temperatureF": 51,
+    "summary": "Sweltering"
+  },
+  {
+    "date": "2023-01-18T19:10:38.978647+03:00",
+    "temperatureC": 25,
+    "temperatureF": 76,
+    "summary": "Balmy"
+  },
+  {
+    "date": "2023-01-19T19:10:38.978647+03:00",
+    "temperatureC": -18,
+    "temperatureF": 0,
+    "summary": "Balmy"
+  }
+]
 ```
 

--- a/samples/ASPNET_Core_Indirect/README.md
+++ b/samples/ASPNET_Core_Indirect/README.md
@@ -1,0 +1,35 @@
+## Scenario with the indirect reference of the Mediator.Abstraction
+
+This example has been created to show the problem in the Source Generator that ignores project
+if they are not directly using any of the types from `Mediator.Abstraction` package,
+but rather include it indirectly through other projects.
+
+`AspNetCoreIndirect.BaseClasses` contains the base classes that are used by the `AspNetCoreIndirect.Implementations`
+project, that provides the implementations of controllers and handlers. `AspNetCoreIndirect.Application` is the entry point
+and references Source Generator.
+
+### Run
+
+Run the application in Visual Studio or through the dotnet CLI.
+The Swagger UI should be visible at [http://localhost:5000/swagger/index.html](http://localhost:5000/swagger/index.html).
+
+#### REST client
+
+Use the `get-weather-forecast.http` file and the "REST Client" VSCode extension to test it out.
+
+You
+
+```http
+GET http://localhost:5000/WeatherForecast
+
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json; charset=utf-8
+Date: Sat, 14 Jan 2023 15:16:08 GMT
+Server: Kestrel
+Transfer-Encoding: chunked
+
+{
+  "message": "No handler registered for message type: AspNetCoreIndirect.Application.GetWeatherForecast"
+}
+```
+

--- a/samples/ASPNET_Core_Indirect/get-weather-forecast.http
+++ b/samples/ASPNET_Core_Indirect/get-weather-forecast.http
@@ -1,0 +1,1 @@
+GET http://localhost:5000/WeatherForecast

--- a/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
@@ -311,11 +311,17 @@ internal sealed class CompilationAnalyzer
             if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol assemblySymbol)
                 continue;
 
-            if (!assemblySymbol.Modules.Any(m => m.ReferencedAssemblies.Any(ra => ra.Name == Constants.MediatorLib)))
+            if (!assemblySymbol.Modules.Any(IsMediatorLibReferencedByTheModule))
                 continue;
 
             queue.Enqueue(assemblySymbol.GlobalNamespace);
         }
+    }
+
+    private static bool IsMediatorLibReferencedByTheModule(IModuleSymbol module)
+    {
+        return module.ReferencedAssemblies.Any(ra => ra.Name == Constants.MediatorLib)
+            || module.ReferencedAssemblySymbols.Any(ra => ra.Modules.Any(IsMediatorLibReferencedByTheModule));
     }
 
     private void PopulateMetadata(Queue<INamespaceOrTypeSymbol> queue)


### PR DESCRIPTION
This PR is to fix the problem described in #75. It also contains en example application that demonstrates indirect `Mediator.Abstractions` usage approach.
