### PR TITLE
Fix build performance regression

### DIFF
--- a/benchmarks/Mediator.Benchmarks/SourceGenerator/SourceGeneratorBenchmark.cs
+++ b/benchmarks/Mediator.Benchmarks/SourceGenerator/SourceGeneratorBenchmark.cs
@@ -1,4 +1,4 @@
-﻿using Mediator.SourceGenerator;
+using Mediator.SourceGenerator;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,6 +12,7 @@ namespace Mediator.Benchmarks.SourceGenerator;
 [Orderer(SummaryOrderPolicy.FastestToSlowest, MethodOrderPolicy.Declared)]
 [InProcess]
 //[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+//[EtwProfiler]
 //[DisassemblyDiagnoser]
 //[InliningDiagnoser(logFailuresOnly: true, allowedNamespaces: new[] { "Mediator" })]
 public class SourceGeneratorBenchmark
@@ -38,7 +39,7 @@ public class SourceGeneratorBenchmark
 
         var projectFile = Path.Combine(
             currentDirectory,
-            "../../samples/ASPNET_CleanArchitecture/AspNetSample.Api/AspNetSample.Api.csproj"
+            "../../samples/ASPNET_Core_CleanArchitecture/AspNetCoreSample.Api/AspNetCoreSample.Api.csproj"
         );
         if (!File.Exists(projectFile))
             throw new Exception("Project doesnt exist");

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -98,14 +98,15 @@ AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
 
 ``` ini
 
-BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
 AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
 .NET SDK=6.0.202
-  [Host] : .NET 6.0.4 (6.0.422.16404), X64 RyuJIT
+  [Host] : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT
 
-Job=InProcess  Toolchain=InProcessEmitToolchain  
+Job=InProcess  Toolchain=InProcessEmitToolchain
 
 ```
-|  Method |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Allocated |
-|-------- |---------:|----------:|----------:|---------:|--------:|----------:|
-| Compile | 5.044 ms | 0.0371 ms | 0.0329 ms | 156.2500 | 31.2500 |      3 MB |
+|  Method |     Mean |    Error |   StdDev |     Gen 0 |   Gen 1 | Allocated |
+|-------- |---------:|---------:|---------:|----------:|--------:|----------:|
+| Compile | 14.52 ms | 0.249 ms | 0.233 ms | 1406.2500 | 31.2500 |     23 MB |
+

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -94,3 +94,18 @@ AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
 |     SendStructRequest_MediatR |       Singleton | 594.018 ns | 7.8648 ns | 7.3568 ns | 119.92 |    3.18 |    5 | 0.0839 |   1,416 B |
 
 
+### Source generation
+
+``` ini
+
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
+.NET SDK=6.0.202
+  [Host] : .NET 6.0.4 (6.0.422.16404), X64 RyuJIT
+
+Job=InProcess  Toolchain=InProcessEmitToolchain  
+
+```
+|  Method |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Allocated |
+|-------- |---------:|----------:|----------:|---------:|--------:|----------:|
+| Compile | 5.044 ms | 0.0371 ms | 0.0329 ms | 156.2500 | 31.2500 |      3 MB |


### PR DESCRIPTION
When we fixed transitive dependency support (#77), it noticably impacted performance. This change tries to mitigate this perf hit. The consequence is that we will stop looking for transitive dependencies when we get 3 levels deep, which I think is reasonable.

Before #77 
``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.202
  [Host] : .NET 6.0.4 (6.0.422.16404), X64 RyuJIT
Job=InProcess  Toolchain=InProcessEmitToolchain  
```
|  Method |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Allocated |
|-------- |---------:|----------:|----------:|---------:|--------:|----------:|
| Compile | 5.044 ms | 0.0371 ms | 0.0329 ms | 156.2500 | 31.2500 |      3 MB |`


<hr />


After #77 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.202
  [Host] : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain  

```
|  Method |     Mean |   Error |  StdDev |      Gen 0 | Allocated |
|-------- |---------:|--------:|--------:|-----------:|----------:|
| Compile | 311.5 ms | 4.77 ms | 4.46 ms | 36500.0000 |    585 MB |


<hr />


With this PR
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.202
  [Host] : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain  

```
|  Method |     Mean |    Error |   StdDev |     Gen 0 |   Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|----------:|--------:|----------:|
| Compile | 14.52 ms | 0.249 ms | 0.233 ms | 1406.2500 | 31.2500 |     23 MB |

