### PR TITLE
feat: refactor `IsMediatorLibReferencedByTheModule` usinng depth search

### DIFF
--- a/benchmarks/Mediator.Benchmarks/Mediator.Benchmarks.csproj
+++ b/benchmarks/Mediator.Benchmarks/Mediator.Benchmarks.csproj
@@ -28,14 +28,16 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="MessagePipe" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.1.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### refactor `IsMediatorLibReferencedByTheModule` using depth search

Keeps the exisitng algorithm using foreach loops (linq used 10MB of `Func<IModuleSymbol, bool>` and closures), uses an assembly cache and tracks if a module has been visited at a lower depth. This will be slower for larger projects as this is depth first, making it harder for `visited` to track if the module will be checked from a lower depth.

### Benchmarks
#### Original
|  Method |     Mean |    Error |   StdDev |      Gen 0 |    Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|-----------:|---------:|----------:|
| Compile | 81.18 ms | 5.526 ms | 16.29 ms | 14500.0000 | 250.0000 |     23 MB |

#### Changes
|  Method |     Mean |    Error |   StdDev |     Gen 0 |    Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|----------:|---------:|----------:|
| Compile | 29.87 ms | 1.744 ms | 5.142 ms | 2909.0909 | 181.8182 |      6 MB |