### PR TITLE
feat: refactor `IsLibReferencedByModule` optimizing source gen for a 66% speed up and 75% less memory usage

### DIFF
--- a/benchmarks/Mediator.Benchmarks/Mediator.Benchmarks.csproj
+++ b/benchmarks/Mediator.Benchmarks/Mediator.Benchmarks.csproj
@@ -28,14 +28,16 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="MessagePipe" Version="1.7.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(DotNetVersion)" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.1.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
+++ b/src/Mediator.SourceGenerator.Implementation/Analysis/CompilationAnalyzer.cs
@@ -315,6 +315,10 @@ internal sealed class CompilationAnalyzer
         if (markerSymbol is null)
             throw new Exception("Can't load marker symbol");
 
+        var assemblyCache = new Dictionary<IModuleSymbol, ImmutableArray<IAssemblySymbol>>(
+            SymbolEqualityComparer.Default
+        );
+
         foreach (var reference in compilation.References)
         {
             if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol assemblySymbol)
@@ -325,30 +329,84 @@ internal sealed class CompilationAnalyzer
             if (assemblySymbol.Name.StartsWith("Mediator.SourceGenerator", StringComparison.Ordinal))
                 continue;
 
-            if (!assemblySymbol.Modules.Any(static m => IsMediatorLibReferencedByTheModule(m, 0)))
+            if (!assemblySymbol.Modules.Any(m => IsMediatorLibReferencedByTheModule(m, assemblyCache)))
                 continue;
 
             queue.Enqueue(assemblySymbol.GlobalNamespace);
         }
     }
 
-    private static bool IsMediatorLibReferencedByTheModule(IModuleSymbol module, int depth)
+    private static bool IsMediatorLibReferencedByTheModule(
+        IModuleSymbol module,
+        Dictionary<IModuleSymbol, ImmutableArray<IAssemblySymbol>> assemblyCache
+    )
     {
-        if (module.ReferencedAssemblies.Any(static ra => ra.Name == Constants.MediatorLib))
-            return true;
+        const int maxDepth = 3;
 
-        // Above we've checked for direct dependencies on the Mediator.Abstractions package,
-        // but projects can implement Mediator messages using only a transitive dependency
-        // as well.
-        // Even so, going too deep recursively will severely impact build performance
-        // so for now the depth is limited to 3.
-        // This should be solved properly by changing how codegen works..
-        if (depth > 3)
-            return false;
+        // Create a queue for breadth-first traversal.
+        var moduleQueue = new Queue<IModuleSymbol>();
 
-        return module.ReferencedAssemblySymbols.Any(
-            ra => ra.Modules.Any(m => IsMediatorLibReferencedByTheModule(m, depth + 1))
-        );
+        // Create a set to keep track of visited modules.
+        var visited = new HashSet<IModuleSymbol>(SymbolEqualityComparer.Default);
+
+        // Enqueue the initial module for processing.
+        moduleQueue.Enqueue(module);
+        visited.Add(module);
+
+        var depth = 0;
+
+        while (moduleQueue.Count > 0)
+        {
+            var count = moduleQueue.Count;
+
+            // Process modules at the current depth level.
+            for (var i = 0; i < count; i++)
+            {
+                var currentModule = moduleQueue.Dequeue();
+
+                // Check if the current module references MediatorLib.
+                if (currentModule.ReferencedAssemblies.Any(ra => ra.Name == Constants.MediatorLib))
+                {
+                    return true;
+                }
+
+                // Above we've checked for direct dependencies on the Mediator.Abstractions package,
+                // but projects can implement Mediator messages using only a transitive dependency
+                // as well.
+                // Even so, going too deep recursively will severely impact build performance
+                // so for now the max depth is limited to 3.
+                // This should be solved properly by changing how codegen works..
+
+                // Access cached assemblies.
+                if (!assemblyCache.TryGetValue(currentModule, out var assemblies))
+                {
+                    assemblies = currentModule.ReferencedAssemblySymbols;
+                    assemblyCache[currentModule] = assemblies;
+                }
+
+                // Enqueue referenced modules for the next depth level.
+                foreach (var assembly in assemblies)
+                {
+                    foreach (var referencedModule in assembly.Modules)
+                    {
+                        if (visited.Add(referencedModule))
+                        {
+                            moduleQueue.Enqueue(referencedModule);
+                        }
+                    }
+                }
+            }
+
+            depth++;
+
+            // Limit the max depth.
+            if (depth > maxDepth)
+            {
+                break;
+            }
+        }
+
+        return false;
     }
 
     private void PopulateMetadata(Queue<INamespaceOrTypeSymbol> queue)


### PR DESCRIPTION
### refactor `IsMediatorLibReferencedByTheModule`
Uses a breadth first algorithm to visit modules, keeping track of visited modules and caching known assemblies. Note that caching known assemblies doesn't make a big impact on the benchmark, but will likely help large projects with lots of references.

I've also created optimize_depth #110. This keeps the exisitng algorithm using foreach loops (linq used 10MB of `Func<IModuleSymbol, bool>` and closures), uses an assmebly cache and tracks if a module has been visited at a lower depth. It has similar performance improvements to this PR but will likely be slower with larger projects.

Related: #7

### Benchmarks
#### Original
|  Method |     Mean |    Error |   StdDev |      Gen 0 |    Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|-----------:|---------:|----------:|
| Compile | 81.18 ms | 5.526 ms | 16.29 ms | 14500.0000 | 250.0000 |     23 MB |

#### Changes
|  Method |     Mean |    Error |   StdDev |     Gen 0 |    Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|----------:|---------:|----------:|
| Compile | 26.55 ms | 1.642 ms | 4.842 ms | 2538.4615 | 307.6923 |      6 MB |