### PR TITLE
feat: add husky to run csharpier on commit

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,18 @@
       "commands": [
         "fixie"
       ]
+    },
+    "husky": {
+      "version": "0.6.3",
+      "commands": [
+        "husky"
+      ]
+    },
+    "csharpier": {
+      "version": "0.16.0",
+      "commands": [
+        "dotnet-csharpier"
+      ]
     }
   }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,10 @@
+{
+    "tasks": [
+        {
+            "name": "Run csharpier",
+            "command": "dotnet",
+            "args": ["csharpier", "${staged}"],
+            "include": ["**/*.cs"]
+        }
+    ]
+}

--- a/src/Mediator/Mediator.csproj
+++ b/src/Mediator/Mediator.csproj
@@ -9,6 +9,12 @@
     </Description>
   </PropertyGroup>
 
+  <Target Name="husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0">
+   <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
+   <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High"
+         WorkingDirectory="../../" />  <!--Update this to the relative path to your project root dir -->
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DotNetVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Added husky to run csharpier on commit

- `src/Mediator/Mediator.csproj` installs husky and csharpier.
- - Pre commit file runs csharpier on push
- Not 100% sure what `CSharpier.MSBuild` in does (assume it checks formatting) so I've updated it to be in line with the latest version of csharpier