### PR TITLE
Add explicit type parameter to `AddMediator` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ There are two ways to configure Mediator. Configuration values are needed during
 * Options configuration delegate in `AddMediator` function.
 
 ```csharp
-services.AddMediator(options =>
+services.AddMediator((MediatorOptions options) =>
 {
     options.Namespace = "SimpleConsole.Mediator";
     options.ServiceLifetime = ServiceLifetime.Transient;
@@ -467,7 +467,7 @@ Both of these try to be efficient by handling a number of special cases (early e
 Below we implement a custom one by simply using `Task.WhenAll`.
 
 ```csharp
-services.AddMediator(options =>
+services.AddMediator((MediatorOptions options) =>
 {
     options.NotificationPublisherType = typeof(FireAndForgetNotificationPublisher);
 });


### PR DESCRIPTION


Should hopefully prevent a couple of occurrences of #139

I'll read the docs later and look for a good place to add information about #139