### PR TITLE
Put internal components in '.Internals' namespace in generated source

### DIFF
--- a/src/Mediator.SourceGenerator/Implementation/Models/CompilationModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/CompilationModel.cs
@@ -152,4 +152,6 @@ internal record CompilationModel
     public bool ConfiguredViaAttribute { get; }
 
     public bool ConfiguredViaConfiguration { get; }
+
+    public string InternalsNamespace => $"{MediatorNamespace}.Internals";
 }

--- a/src/Mediator.SourceGenerator/Implementation/Models/NotificationMessageModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/NotificationMessageModel.cs
@@ -19,7 +19,7 @@ internal sealed record NotificationMessageModel : SymbolMetadataModel
             .GetTypeSymbolFullName(withGlobalPrefix: false, includeTypeParameters: false)
             .Replace("global::", "")
             .Replace('.', '_');
-        FullNamespace = $"global::{analyzer.MediatorNamespace}";
+        HandlerWrapperNamespace = $"global::{analyzer.MediatorNamespace}.Internals";
     }
 
     public string IdentifierFullName { get; }
@@ -28,12 +28,12 @@ internal sealed record NotificationMessageModel : SymbolMetadataModel
 
     public string? ServiceLifetime { get; }
 
-    public string FullNamespace { get; }
+    public string HandlerWrapperNamespace { get; }
 
     public string HandlerTypeOfExpression => $"typeof(global::Mediator.INotificationHandler<{FullName}>)";
 
     public string HandlerWrapperTypeNameWithGenericTypeArguments =>
-        $"{FullNamespace}.NotificationHandlerWrapper<{FullName}>";
+        $"{HandlerWrapperNamespace}.NotificationHandlerWrapper<{FullName}>";
 
     public string HandlerWrapperPropertyName => $"Wrapper_For_{IdentifierFullName}";
 

--- a/src/Mediator.SourceGenerator/Implementation/Models/RequestMessageHandlerWrapperModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/RequestMessageHandlerWrapperModel.cs
@@ -5,7 +5,7 @@ internal sealed record RequestMessageHandlerWrapperModel
     public RequestMessageHandlerWrapperModel(string messageType, CompilationAnalyzer analyzer)
     {
         MessageType = messageType;
-        FullNamespace = $"global::{analyzer.MediatorNamespace}";
+        FullNamespace = $"global::{analyzer.MediatorNamespace}.Internals";
     }
 
     public string MessageType { get; }

--- a/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {{~ for registration in message.HandlerServicesRegistrationBlock ~}}
             {{ registration }}
             {{~ end ~}}
-            services.Add(new SD(typeof(global::{{ MediatorNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), typeof(global::{{ MediatorNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), {{ SingletonServiceLifetime }}));
+            services.Add(new SD(typeof(global::{{ InternalsNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), typeof(global::{{ InternalsNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), {{ SingletonServiceLifetime }}));
             {{~ end ~}}
 
             {{~ for handler in OpenGenericNotificationMessageHandlers ~}}
@@ -96,10 +96,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<{{ NotificationPublisherType.FullName }}>(), {{ SingletonServiceLifetime }}));
             {{~ end ~}}
 
-            services.Add(new SD(typeof(global::{{ MediatorNamespace }}.IContainerProbe), typeof(global::{{ MediatorNamespace }}.ContainerProbe0), {{ ServiceLifetime }}));
-            services.Add(new SD(typeof(global::{{ MediatorNamespace }}.IContainerProbe), typeof(global::{{ MediatorNamespace }}.ContainerProbe1), {{ ServiceLifetime }}));
+            services.Add(new SD(typeof(global::{{ InternalsNamespace }}.IContainerProbe), typeof(global::{{ InternalsNamespace }}.ContainerProbe0), {{ ServiceLifetime }}));
+            services.Add(new SD(typeof(global::{{ InternalsNamespace }}.IContainerProbe), typeof(global::{{ InternalsNamespace }}.ContainerProbe1), {{ ServiceLifetime }}));
 
-            services.Add(new SD(typeof(global::{{ MediatorNamespace }}.ContainerMetadata), typeof(global::{{ MediatorNamespace }}.ContainerMetadata), {{ SingletonServiceLifetime }}));
+            services.Add(new SD(typeof(global::{{ InternalsNamespace }}.ContainerMetadata), typeof(global::{{ InternalsNamespace }}.ContainerMetadata), {{ SingletonServiceLifetime }}));
 
             return services;
 
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace {{ MediatorNamespace }}
+namespace {{ InternalsNamespace }}
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "{{ GeneratorVersion }}")]
     internal interface IMessageHandlerBase
@@ -169,7 +169,7 @@ namespace {{ MediatorNamespace }}
         private {{ wrapperType.MessageHandlerDelegateName }} _rootHandler = null!;
 
         public {{ wrapperType.HandlerWrapperTypeNameWithGenericTypeParameters }} Init(
-            global::{{ MediatorNamespace }}.ContainerMetadata containerMetadata,
+            global::{{ InternalsNamespace }}.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -305,7 +305,7 @@ namespace {{ MediatorNamespace }}
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::{{ MediatorNamespace }}.ContainerMetadata containerMetadata,
+            global::{{ InternalsNamespace }}.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -451,10 +451,10 @@ namespace {{ MediatorNamespace }}
             {{~ if ServiceLifetimeIsScoped ~}}
             using (var scope = sp.CreateScope())
             {
-                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::{{ MediatorNamespace }}.IContainerProbe>() is global::{{ MediatorNamespace }}.IContainerProbe[];
+                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::{{ InternalsNamespace }}.IContainerProbe>() is global::{{ InternalsNamespace }}.IContainerProbe[];
             }
             {{~ else ~}}
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::{{ MediatorNamespace }}.IContainerProbe>() is global::{{ MediatorNamespace }}.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::{{ InternalsNamespace }}.IContainerProbe>() is global::{{ InternalsNamespace }}.IContainerProbe[];
             {{~ end ~}}
 
             {{~ if ServiceLifetimeIsSingleton ~}}
@@ -528,7 +528,10 @@ namespace {{ MediatorNamespace }}
             {{~ end ~}}
         }
     }
+}
 
+namespace {{ MediatorNamespace }}
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -541,7 +544,7 @@ namespace {{ MediatorNamespace }}
     {
         internal readonly global::System.IServiceProvider Services;
         {{~ if ServiceLifetimeIsSingleton ~}}
-        {{ if IsTestRun }}internal{{ else }}private{{ end }} FastLazyValue<global::{{ MediatorNamespace }}.ContainerMetadata, global::{{ MediatorNamespace }}.Mediator> _containerMetadata;
+        {{ if IsTestRun }}internal{{ else }}private{{ end }} FastLazyValue<global::{{ InternalsNamespace }}.ContainerMetadata, global::{{ MediatorNamespace }}.Mediator> _containerMetadata;
         private {{ NotificationPublisherType.FullName }}? _notificationPublisher;
         internal {{ NotificationPublisherType.FullName }} NotificationPublisher
         {
@@ -565,15 +568,15 @@ namespace {{ MediatorNamespace }}
             }
         }
         {{~ else ~}}
-        private global::{{ MediatorNamespace }}.ContainerMetadata? _containerMetadataStorage;
-        private global::{{ MediatorNamespace }}.ContainerMetadata _containerMetadata
+        private global::{{ InternalsNamespace }}.ContainerMetadata? _containerMetadataStorage;
+        private global::{{ InternalsNamespace }}.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::{{ MediatorNamespace }}.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::{{ InternalsNamespace }}.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }
@@ -616,8 +619,8 @@ namespace {{ MediatorNamespace }}
         {
             Services = sp;
             {{~ if ServiceLifetimeIsSingleton ~}}
-            _containerMetadata = new FastLazyValue<global::{{ MediatorNamespace }}.ContainerMetadata, global::{{ MediatorNamespace }}.Mediator>(
-                self => self.Services.GetRequiredService<global::{{ MediatorNamespace }}.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::{{ InternalsNamespace }}.ContainerMetadata, global::{{ MediatorNamespace }}.Mediator>(
+                self => self.Services.GetRequiredService<global::{{ InternalsNamespace }}.ContainerMetadata>(),
                 this
             );
             {{~ end ~}}
@@ -955,9 +958,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasRequests ~}}
             {{~ if HasManyRequests ~}}
             var handlerObj = GetRequestHandler(request);
-            if (handlerObj is global::{{ MediatorNamespace }}.IRequestHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.IRequestHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.IRequestHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.IRequestHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken);
             }
             return SendAsync(request, handlerObj, cancellationToken);
@@ -998,7 +1001,7 @@ namespace {{ MediatorNamespace }}
         {
             {{~ if HasRequests ~}}
             {{~ if HasManyRequests ~}}
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
             var response = await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken);
             return global::System.Runtime.CompilerServices.Unsafe.As<object?, TResponse>(ref response);
             {{~ else ~}}
@@ -1041,9 +1044,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasStreamRequests ~}}
             {{~ if HasManyStreamRequests ~}}
             var handlerObj = GetStreamRequestHandler(request);
-            if (handlerObj is global::{{ MediatorNamespace }}.IStreamRequestHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.IStreamRequestHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.IStreamRequestHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.IStreamRequestHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken);
             }
             return CreateStreamAsync(request, handlerObj, cancellationToken);
@@ -1077,7 +1080,7 @@ namespace {{ MediatorNamespace }}
             [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default
         )
         {
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
             await foreach (var r in handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken))
             {
                 yield return (TResponse)r!;
@@ -1102,9 +1105,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasCommands ~}}
             {{~ if HasManyCommands ~}}
             var handlerObj = GetCommandHandler(command);
-            if (handlerObj is global::{{ MediatorNamespace }}.ICommandHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.ICommandHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.ICommandHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.ICommandHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken);
             }
             return SendAsync(command, handlerObj, cancellationToken);
@@ -1145,7 +1148,7 @@ namespace {{ MediatorNamespace }}
         {
             {{~ if HasCommands ~}}
             {{~ if HasManyCommands ~}}
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
             var response = await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken);
             return global::System.Runtime.CompilerServices.Unsafe.As<object?, TResponse>(ref response);
             {{~ else ~}}
@@ -1188,9 +1191,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasStreamCommands ~}}
             {{~ if HasManyStreamCommands ~}}
             var handlerObj = GetStreamCommandHandler(command);
-            if (handlerObj is global::{{ MediatorNamespace }}.IStreamCommandHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.IStreamCommandHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.IStreamCommandHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.IStreamCommandHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken);
             }
             return CreateStreamAsync(command, handlerObj, cancellationToken);
@@ -1224,7 +1227,7 @@ namespace {{ MediatorNamespace }}
             [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default
         )
         {
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
             await foreach (var r in handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken))
             {
                 yield return (TResponse)r!;
@@ -1249,9 +1252,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasQueries ~}}
             {{~ if HasManyQueries ~}}
             var handlerObj = GetQueryHandler(query);
-            if (handlerObj is global::{{ MediatorNamespace }}.IQueryHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.IQueryHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.IQueryHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.IQueryHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken);
             }
             return SendAsync(query, handlerObj, cancellationToken);
@@ -1292,7 +1295,7 @@ namespace {{ MediatorNamespace }}
         {
             {{~ if HasQueries ~}}
             {{~ if HasManyQueries ~}}
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
             var response = await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken);
             return global::System.Runtime.CompilerServices.Unsafe.As<object?, TResponse>(ref response);
             {{~ else ~}}
@@ -1335,9 +1338,9 @@ namespace {{ MediatorNamespace }}
             {{~ if HasStreamQueries ~}}
             {{~ if HasManyStreamQueries ~}}
             var handlerObj = GetStreamQueryHandler(query);
-            if (handlerObj is global::{{ MediatorNamespace }}.IStreamQueryHandlerBase<TResponse>)
+            if (handlerObj is global::{{ InternalsNamespace }}.IStreamQueryHandlerBase<TResponse>)
             {
-                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ MediatorNamespace }}.IStreamQueryHandlerBase<TResponse>>(ref handlerObj);
+                ref var handler = ref global::System.Runtime.CompilerServices.Unsafe.As<object, global::{{ InternalsNamespace }}.IStreamQueryHandlerBase<TResponse>>(ref handlerObj);
                 return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken);
             }
             return CreateStreamAsync(query, handlerObj, cancellationToken);
@@ -1371,7 +1374,7 @@ namespace {{ MediatorNamespace }}
             [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default
         )
         {
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
             await foreach (var r in handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken))
             {
                 yield return (TResponse)r!;
@@ -1401,10 +1404,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetRequestHandler(request);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
                         return await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1425,10 +1428,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetCommandHandler(command);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
                         return await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1449,10 +1452,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetQueryHandler(query);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IMessageHandlerBase>(handlerObj);
                         return await handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1500,10 +1503,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetStreamRequestHandler(request);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IStreamMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IStreamMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
                         return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}request, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1532,10 +1535,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetStreamCommandHandler(command);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IStreamMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IStreamMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
                         return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}command, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1564,10 +1567,10 @@ namespace {{ MediatorNamespace }}
                     {
                         var handlerObj = GetStreamQueryHandler(query);
                         global::System.Diagnostics.Debug.Assert(
-                            handlerObj is global::{{ MediatorNamespace }}.IStreamMessageHandlerBase,
+                            handlerObj is global::{{ InternalsNamespace }}.IStreamMessageHandlerBase,
                             $"Unexpected type: {handlerObj.GetType()}"
                         );
-                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.IStreamMessageHandlerBase>(handlerObj);
+                        var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.IStreamMessageHandlerBase>(handlerObj);
                         return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}query, cancellationToken);
                     }
                     {{~ else ~}}
@@ -1634,10 +1637,10 @@ namespace {{ MediatorNamespace }}
                 {
                     var handlerObj = GetNotificationHandler(n);
                     global::System.Diagnostics.Debug.Assert(
-                        handlerObj is global::{{ MediatorNamespace }}.INotificationHandlerBase,
+                        handlerObj is global::{{ InternalsNamespace }}.INotificationHandlerBase,
                         $"Unexpected type: {handlerObj.GetType()}"
                     );
-                    var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.INotificationHandlerBase>(handlerObj);
+                    var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.INotificationHandlerBase>(handlerObj);
                     return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}n, cancellationToken);
                 }
                 {{~ else ~}}
@@ -1682,10 +1685,10 @@ namespace {{ MediatorNamespace }}
             {{~ else ~}}
             var handlerObj = GetNotificationHandler(notification);
             global::System.Diagnostics.Debug.Assert(
-                handlerObj is global::{{ MediatorNamespace }}.INotificationHandlerBase,
+                handlerObj is global::{{ InternalsNamespace }}.INotificationHandlerBase,
                 $"Unexpected type: {handlerObj.GetType()}"
             );
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.INotificationHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.INotificationHandlerBase>(handlerObj);
             return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}notification, cancellationToken);
             {{~ end ~}}
         }
@@ -1710,10 +1713,10 @@ namespace {{ MediatorNamespace }}
             {{~ if HasManyNotifications ~}}
             var handlerObj = GetNotificationHandler(notification);
             global::System.Diagnostics.Debug.Assert(
-                handlerObj is global::{{ MediatorNamespace }}.INotificationHandlerBase,
+                handlerObj is global::{{ InternalsNamespace }}.INotificationHandlerBase,
                 $"Unexpected type: {handlerObj.GetType()}"
             );
-            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ MediatorNamespace }}.INotificationHandlerBase>(handlerObj);
+            var handler = global::System.Runtime.CompilerServices.Unsafe.As<global::{{ InternalsNamespace }}.INotificationHandlerBase>(handlerObj);
             return handler.Handle({{ if !ServiceLifetimeIsSingleton; "this, "; end; }}notification, cancellationToken);
             {{~ else ~}}
             switch (notification)

--- a/test/Mediator.SmokeTestConsole/Program.cs
+++ b/test/Mediator.SmokeTestConsole/Program.cs
@@ -6,8 +6,8 @@ using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using ContainerMetadata = Mediator.ContainerMetadata;
-using LazyContainerMetadata = Mediator.Mediator.FastLazyValue<Mediator.ContainerMetadata, Mediator.Mediator>;
+using ContainerMetadata = Mediator.Internals.ContainerMetadata;
+using LazyContainerMetadata = Mediator.Mediator.FastLazyValue<Mediator.Internals.ContainerMetadata, Mediator.Mediator>;
 
 await Host.CreateDefaultBuilder()
     .ConfigureLogging(

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_ForEachAwaitPublisher_Default#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_ForEachAwaitPublisher_Default#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_TaskWhenAllPublisher_For_Notifications_AddMediator#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_TaskWhenAllPublisher_For_Notifications_AddMediator#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.TaskWhenAllPublisher), typeof(global::Mediator.TaskWhenAllPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.TaskWhenAllPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.TaskWhenAllPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.TaskWhenAllPublisher? _notificationPublisher;
         internal global::Mediator.TaskWhenAllPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_TaskWhenAllPublisher_For_Notifications_Attribute#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ConfigurationTests.Test_TaskWhenAllPublisher_For_Notifications_Attribute#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.TaskWhenAllPublisher), typeof(global::Mediator.TaskWhenAllPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.TaskWhenAllPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.TaskWhenAllPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.TaskWhenAllPublisher? _notificationPublisher;
         internal global::Mediator.TaskWhenAllPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/LifetimeOptionTests.Test_No_Args#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/LifetimeOptionTests.Test_No_Args#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/LifetimeOptionTests.Test_Transient_Lifetime_With_Named_Namespace_Arg#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/LifetimeOptionTests.Test_Transient_Lifetime_With_Named_Namespace_Arg#Mediator.g.verified.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
             
-            services.Add(new SD(typeof(global::Mediator2.IContainerProbe), typeof(global::Mediator2.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
-            services.Add(new SD(typeof(global::Mediator2.IContainerProbe), typeof(global::Mediator2.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
+            services.Add(new SD(typeof(global::Mediator2.Internals.IContainerProbe), typeof(global::Mediator2.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
+            services.Add(new SD(typeof(global::Mediator2.Internals.IContainerProbe), typeof(global::Mediator2.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
 
-            services.Add(new SD(typeof(global::Mediator2.ContainerMetadata), typeof(global::Mediator2.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator2.Internals.ContainerMetadata), typeof(global::Mediator2.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator2
+namespace Mediator2.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -646,7 +646,7 @@ namespace Mediator2
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator2.IContainerProbe>() is global::Mediator2.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator2.Internals.IContainerProbe>() is global::Mediator2.Internals.IContainerProbe[];
 
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
@@ -674,7 +674,10 @@ namespace Mediator2
 
         }
     }
+}
 
+namespace Mediator2
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -686,15 +689,15 @@ namespace Mediator2
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private global::Mediator2.ContainerMetadata? _containerMetadataStorage;
-        private global::Mediator2.ContainerMetadata _containerMetadata
+        private global::Mediator2.Internals.ContainerMetadata? _containerMetadataStorage;
+        private global::Mediator2.Internals.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::Mediator2.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::Mediator2.Internals.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/MessageOrderingTests.Test_Notifications_Ordering#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/MessageOrderingTests.Test_Notifications_Ordering#Mediator.g.verified.cs
@@ -60,21 +60,21 @@ namespace Microsoft.Extensions.DependencyInjection
 
 
 
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
 
 
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -685,17 +685,17 @@ namespace Mediator
 
 
 
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually> Wrapper_For_TestCode_RoundSucceededActually;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated> Wrapper_For_TestCode_RoundCreated;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted> Wrapper_For_TestCode_RoundResulted;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded> Wrapper_For_TestCode_RoundSucceeded;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent> Wrapper_For_TestCode_DomainEvent;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually> Wrapper_For_TestCode_RoundSucceededActually;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated> Wrapper_For_TestCode_RoundCreated;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted> Wrapper_For_TestCode_RoundResulted;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded> Wrapper_For_TestCode_RoundSucceeded;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent> Wrapper_For_TestCode_DomainEvent;
 
         public readonly global::Mediator.ForeachAwaitPublisher NotificationPublisher;
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -714,11 +714,11 @@ namespace Mediator
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
 
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(5);
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceededActually), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundCreated), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundResulted), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceeded), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceededActually), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundCreated), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundResulted), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceeded), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp));
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
 
@@ -727,14 +727,17 @@ namespace Mediator
 
 
 
-            Wrapper_For_TestCode_RoundSucceededActually = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundCreated = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundResulted = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundSucceeded = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp);
-            Wrapper_For_TestCode_DomainEvent = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundSucceededActually = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundCreated = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundResulted = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundSucceeded = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp);
+            Wrapper_For_TestCode_DomainEvent = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp);
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -746,7 +749,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -791,8 +794,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/MessageOrderingTests.Test_Notifications_Ordering_Bigger#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/MessageOrderingTests.Test_Notifications_Ordering_Bigger#Mediator.g.verified.cs
@@ -60,26 +60,26 @@ namespace Microsoft.Extensions.DependencyInjection
 
 
 
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Created>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Created>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Resulted>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Resulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent2>), typeof(global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent2>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Created>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Created>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Resulted>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Resulted>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent2>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent2>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
 
 
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -133,7 +133,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -213,7 +213,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -294,7 +294,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -374,7 +374,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -455,7 +455,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -535,7 +535,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -610,7 +610,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -690,22 +690,22 @@ namespace Mediator
 
 
 
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually> Wrapper_For_TestCode_RoundSucceededActually;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually> Wrapper_For_TestCode_Round2SucceededActually;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated> Wrapper_For_TestCode_RoundCreated;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted> Wrapper_For_TestCode_RoundResulted;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded> Wrapper_For_TestCode_RoundSucceeded;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Created> Wrapper_For_TestCode_Round2Created;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Resulted> Wrapper_For_TestCode_Round2Resulted;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Succeeded> Wrapper_For_TestCode_Round2Succeeded;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent> Wrapper_For_TestCode_DomainEvent;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent2> Wrapper_For_TestCode_DomainEvent2;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually> Wrapper_For_TestCode_RoundSucceededActually;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually> Wrapper_For_TestCode_Round2SucceededActually;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated> Wrapper_For_TestCode_RoundCreated;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted> Wrapper_For_TestCode_RoundResulted;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded> Wrapper_For_TestCode_RoundSucceeded;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Created> Wrapper_For_TestCode_Round2Created;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Resulted> Wrapper_For_TestCode_Round2Resulted;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Succeeded> Wrapper_For_TestCode_Round2Succeeded;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent> Wrapper_For_TestCode_DomainEvent;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent2> Wrapper_For_TestCode_DomainEvent2;
 
         public readonly global::Mediator.ForeachAwaitPublisher NotificationPublisher;
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -724,16 +724,16 @@ namespace Mediator
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
 
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(10);
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceededActually), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.Round2SucceededActually), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundCreated), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundResulted), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceeded), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Created), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Created>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Resulted), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Resulted>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Succeeded), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent2), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent2>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceededActually), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.Round2SucceededActually), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundCreated), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundResulted), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.RoundSucceeded), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Created), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Created>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Resulted), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Resulted>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.Round2Succeeded), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::TestCode.DomainEvent2), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent2>>().Init(this, sp));
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
 
@@ -742,19 +742,22 @@ namespace Mediator
 
 
 
-            Wrapper_For_TestCode_RoundSucceededActually = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp);
-            Wrapper_For_TestCode_Round2SucceededActually = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundCreated = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundResulted = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp);
-            Wrapper_For_TestCode_RoundSucceeded = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp);
-            Wrapper_For_TestCode_Round2Created = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Created>>().Init(this, sp);
-            Wrapper_For_TestCode_Round2Resulted = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Resulted>>().Init(this, sp);
-            Wrapper_For_TestCode_Round2Succeeded = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>>().Init(this, sp);
-            Wrapper_For_TestCode_DomainEvent = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp);
-            Wrapper_For_TestCode_DomainEvent2 = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::TestCode.DomainEvent2>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundSucceededActually = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceededActually>>().Init(this, sp);
+            Wrapper_For_TestCode_Round2SucceededActually = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2SucceededActually>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundCreated = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundCreated>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundResulted = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundResulted>>().Init(this, sp);
+            Wrapper_For_TestCode_RoundSucceeded = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.RoundSucceeded>>().Init(this, sp);
+            Wrapper_For_TestCode_Round2Created = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Created>>().Init(this, sp);
+            Wrapper_For_TestCode_Round2Resulted = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Resulted>>().Init(this, sp);
+            Wrapper_For_TestCode_Round2Succeeded = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.Round2Succeeded>>().Init(this, sp);
+            Wrapper_For_TestCode_DomainEvent = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent>>().Init(this, sp);
+            Wrapper_For_TestCode_DomainEvent2 = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::TestCode.DomainEvent2>>().Init(this, sp);
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -766,7 +769,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -811,8 +814,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Abstract_Handler_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Abstract_Handler_Program#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Byte_Array_Response_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Byte_Array_Response_Program#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::Some.Nested.Types.Program.PingHandler), typeof(global::Some.Nested.Types.Program.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>), typeof(global::Some.Nested.Types.Program.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]> Wrapper_For_Some_Nested_Types_Program_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]> Wrapper_For_Some_Nested_Types_Program_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Some.Nested.Types.Program.Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Some.Nested.Types.Program.Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Some_Nested_Types_Program_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>>().Init(this, sp);
+            Wrapper_For_Some_Nested_Types_Program_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::System.Byte[]>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Const_Variable_In_Config#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Const_Variable_In_Config#Mediator.g.verified.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
             
-            services.Add(new SD(typeof(global::SimpleConsole.Mediator.IContainerProbe), typeof(global::SimpleConsole.Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
-            services.Add(new SD(typeof(global::SimpleConsole.Mediator.IContainerProbe), typeof(global::SimpleConsole.Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
+            services.Add(new SD(typeof(global::SimpleConsole.Mediator.Internals.IContainerProbe), typeof(global::SimpleConsole.Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
+            services.Add(new SD(typeof(global::SimpleConsole.Mediator.Internals.IContainerProbe), typeof(global::SimpleConsole.Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient));
 
-            services.Add(new SD(typeof(global::SimpleConsole.Mediator.ContainerMetadata), typeof(global::SimpleConsole.Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsole.Mediator.Internals.ContainerMetadata), typeof(global::SimpleConsole.Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace SimpleConsole.Mediator
+namespace SimpleConsole.Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -646,7 +646,7 @@ namespace SimpleConsole.Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsole.Mediator.IContainerProbe>() is global::SimpleConsole.Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsole.Mediator.Internals.IContainerProbe>() is global::SimpleConsole.Mediator.Internals.IContainerProbe[];
 
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
@@ -674,7 +674,10 @@ namespace SimpleConsole.Mediator
 
         }
     }
+}
 
+namespace SimpleConsole.Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -686,15 +689,15 @@ namespace SimpleConsole.Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private global::SimpleConsole.Mediator.ContainerMetadata? _containerMetadataStorage;
-        private global::SimpleConsole.Mediator.ContainerMetadata _containerMetadata
+        private global::SimpleConsole.Mediator.Internals.ContainerMetadata? _containerMetadataStorage;
+        private global::SimpleConsole.Mediator.Internals.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::SimpleConsole.Mediator.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::SimpleConsole.Mediator.Internals.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Deep_Namespace_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Deep_Namespace_Program#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.PingHandler), typeof(global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>), typeof(global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong> Wrapper_For_Some_Very_Very_Very_Very_Deep_Namespace_ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong> Wrapper_For_Some_Very_Very_Very_Very_Deep_Namespace_ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Some_Very_Very_Very_Very_Deep_Namespace_ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>>().Init(this, sp);
+            Wrapper_For_Some_Very_Very_Very_Very_Deep_Namespace_ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Ping, global::Some.Very.Very.Very.Very.Deep.Namespace.ThatIUseToTestTheSourceGenSoThatItCanHandleLotsOfDifferentInput.Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Duplicate_Handlers#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Duplicate_Handlers#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Ping, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
+            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Empty_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Empty_Program#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Handler_Type#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Handler_Type#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Local_Literal_Variable_In_Config#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Local_Literal_Variable_In_Config#Mediator.g.verified.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             
-            services.Add(new SD(typeof(global::SomeNamespace.IContainerProbe), typeof(global::SomeNamespace.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
-            services.Add(new SD(typeof(global::SomeNamespace.IContainerProbe), typeof(global::SomeNamespace.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.IContainerProbe), typeof(global::SomeNamespace.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.IContainerProbe), typeof(global::SomeNamespace.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
 
-            services.Add(new SD(typeof(global::SomeNamespace.ContainerMetadata), typeof(global::SomeNamespace.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.ContainerMetadata), typeof(global::SomeNamespace.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace SomeNamespace
+namespace SomeNamespace.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -648,7 +648,7 @@ namespace SomeNamespace
         {
             using (var scope = sp.CreateScope())
             {
-                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::SomeNamespace.IContainerProbe>() is global::SomeNamespace.IContainerProbe[];
+                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::SomeNamespace.Internals.IContainerProbe>() is global::SomeNamespace.Internals.IContainerProbe[];
             }
 
 
@@ -677,7 +677,10 @@ namespace SomeNamespace
 
         }
     }
+}
 
+namespace SomeNamespace
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -689,15 +692,15 @@ namespace SomeNamespace
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private global::SomeNamespace.ContainerMetadata? _containerMetadataStorage;
-        private global::SomeNamespace.ContainerMetadata _containerMetadata
+        private global::SomeNamespace.Internals.ContainerMetadata? _containerMetadataStorage;
+        private global::SomeNamespace.Internals.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::SomeNamespace.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::SomeNamespace.Internals.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Local_Variables_Referencing_Consts_Config#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Local_Variables_Referencing_Consts_Config#Mediator.g.verified.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             
-            services.Add(new SD(typeof(global::SomeNamespace.IContainerProbe), typeof(global::SomeNamespace.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
-            services.Add(new SD(typeof(global::SomeNamespace.IContainerProbe), typeof(global::SomeNamespace.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.IContainerProbe), typeof(global::SomeNamespace.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.IContainerProbe), typeof(global::SomeNamespace.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
 
-            services.Add(new SD(typeof(global::SomeNamespace.ContainerMetadata), typeof(global::SomeNamespace.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SomeNamespace.Internals.ContainerMetadata), typeof(global::SomeNamespace.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace SomeNamespace
+namespace SomeNamespace.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -648,7 +648,7 @@ namespace SomeNamespace
         {
             using (var scope = sp.CreateScope())
             {
-                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::SomeNamespace.IContainerProbe>() is global::SomeNamespace.IContainerProbe[];
+                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::SomeNamespace.Internals.IContainerProbe>() is global::SomeNamespace.Internals.IContainerProbe[];
             }
 
 
@@ -677,7 +677,10 @@ namespace SomeNamespace
 
         }
     }
+}
 
+namespace SomeNamespace
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -689,15 +692,15 @@ namespace SomeNamespace
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private global::SomeNamespace.ContainerMetadata? _containerMetadataStorage;
-        private global::SomeNamespace.ContainerMetadata _containerMetadata
+        private global::SomeNamespace.Internals.ContainerMetadata? _containerMetadataStorage;
+        private global::SomeNamespace.Internals.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::SomeNamespace.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::SomeNamespace.Internals.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_AddMediator_Calls#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_AddMediator_Calls#Mediator.g.verified.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
             
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -648,7 +648,7 @@ namespace Mediator
         {
             using (var scope = sp.CreateScope())
             {
-                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+                ServicesUnderlyingTypeIsArray = scope.ServiceProvider.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
             }
 
 
@@ -677,7 +677,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -689,15 +692,15 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private global::Mediator.ContainerMetadata? _containerMetadataStorage;
-        private global::Mediator.ContainerMetadata _containerMetadata
+        private global::Mediator.Internals.ContainerMetadata? _containerMetadataStorage;
+        private global::Mediator.Internals.ContainerMetadata _containerMetadata
         {
             [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
                 if (_containerMetadataStorage == null)
                 {
-                    var containerMetadata = Services.GetRequiredService<global::Mediator.ContainerMetadata>();
+                    var containerMetadata = Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>();
                     _containerMetadataStorage = containerMetadata;
                     return containerMetadata;
                 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_Errors#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_Errors#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Ping, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
+            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_No_Messages_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_No_Messages_Program#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Null_Namespace_Variable#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Null_Namespace_Variable#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Request_Without_Handler_Warning#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Request_Without_Handler_Warning#Mediator.g.verified.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -121,7 +121,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -201,7 +201,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -282,7 +282,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -362,7 +362,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -443,7 +443,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -523,7 +523,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -598,7 +598,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -683,7 +683,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -712,7 +712,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -724,7 +727,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -769,8 +772,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Static_Nested_Handler_Program#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Static_Nested_Handler_Program#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::Some.Nested.Types.Program.PingHandler), typeof(global::Some.Nested.Types.Program.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>), typeof(global::Some.Nested.Types.Program.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong> Wrapper_For_Some_Nested_Types_Program_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong> Wrapper_For_Some_Nested_Types_Program_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Some.Nested.Types.Program.Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Some.Nested.Types.Program.Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Some_Nested_Types_Program_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>>().Init(this, sp);
+            Wrapper_For_Some_Nested_Types_Program_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Some.Nested.Types.Program.Ping, global::Some.Nested.Types.Program.Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ASPNET_Core_CleanArchitecture_Sample#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ASPNET_Core_CleanArchitecture_Sample#Mediator.g.verified.cs
@@ -61,15 +61,15 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::AspNetCoreSample.Application.TodoItemCommandHandler), typeof(global::AspNetCoreSample.Application.TodoItemCommandHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.ICommandHandler<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>), typeof(global::AspNetCoreSample.Application.TodoItemCommandHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>),
-                typeof(global::Mediator.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>),
+                typeof(global::Mediator.Internals.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>),
+                typeof(global::Mediator.Internals.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
             services.TryAdd(new SD(typeof(global::AspNetCoreSample.Application.TodoItemQueryHandler), typeof(global::AspNetCoreSample.Application.TodoItemQueryHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IQueryHandler<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>), typeof(global::AspNetCoreSample.Application.TodoItemQueryHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>),
-                typeof(global::Mediator.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>),
+                typeof(global::Mediator.Internals.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>),
+                typeof(global::Mediator.Internals.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -80,10 +80,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -135,7 +135,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -215,7 +215,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -296,7 +296,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -376,7 +376,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -457,7 +457,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -537,7 +537,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -612,7 +612,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -687,9 +687,9 @@ namespace Mediator
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
 
-        public readonly global::Mediator.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem> Wrapper_For_AspNetCoreSample_Application_AddTodoItem;
+        public readonly global::Mediator.Internals.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem> Wrapper_For_AspNetCoreSample_Application_AddTodoItem;
 
-        public readonly global::Mediator.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>> Wrapper_For_AspNetCoreSample_Application_GetTodoItems;
+        public readonly global::Mediator.Internals.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>> Wrapper_For_AspNetCoreSample_Application_GetTodoItems;
 
 
 
@@ -699,15 +699,15 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
-            commandHandlerTypes.Add(typeof(global::AspNetCoreSample.Application.AddTodoItem), sp.GetRequiredService<global::Mediator.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>>().Init(this, sp));
-            queryHandlerTypes.Add(typeof(global::AspNetCoreSample.Application.GetTodoItems), sp.GetRequiredService<global::Mediator.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>>().Init(this, sp));
+            commandHandlerTypes.Add(typeof(global::AspNetCoreSample.Application.AddTodoItem), sp.GetRequiredService<global::Mediator.Internals.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>>().Init(this, sp));
+            queryHandlerTypes.Add(typeof(global::AspNetCoreSample.Application.GetTodoItems), sp.GetRequiredService<global::Mediator.Internals.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -723,16 +723,19 @@ namespace Mediator
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
 
-            Wrapper_For_AspNetCoreSample_Application_AddTodoItem = sp.GetRequiredService<global::Mediator.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>>().Init(this, sp);
+            Wrapper_For_AspNetCoreSample_Application_AddTodoItem = sp.GetRequiredService<global::Mediator.Internals.CommandHandlerWrapper<global::AspNetCoreSample.Application.AddTodoItem, global::AspNetCoreSample.Domain.TodoItem>>().Init(this, sp);
 
-            Wrapper_For_AspNetCoreSample_Application_GetTodoItems = sp.GetRequiredService<global::Mediator.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>>().Init(this, sp);
+            Wrapper_For_AspNetCoreSample_Application_GetTodoItems = sp.GetRequiredService<global::Mediator.Internals.QueryHandlerWrapper<global::AspNetCoreSample.Application.GetTodoItems, global::System.Collections.Generic.IEnumerable<global::AspNetCoreSample.Domain.TodoItem>>>().Init(this, sp);
 
 
 
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -744,7 +747,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -789,8 +792,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ASPNET_Core_Indirect_Sample#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ASPNET_Core_Indirect_Sample#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::AspNetCoreIndirect.Application.Controllers.GetWeatherForecastHandler), typeof(global::AspNetCoreIndirect.Application.Controllers.GetWeatherForecastHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>), typeof(global::AspNetCoreIndirect.Application.Controllers.GetWeatherForecastHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>> Wrapper_For_AspNetCoreIndirect_Application_GetWeatherForecast;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>> Wrapper_For_AspNetCoreIndirect_Application_GetWeatherForecast;
 
 
 
@@ -691,14 +691,14 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::AspNetCoreIndirect.Application.GetWeatherForecast), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::AspNetCoreIndirect.Application.GetWeatherForecast), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace Mediator
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_AspNetCoreIndirect_Application_GetWeatherForecast = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>>().Init(this, sp);
+            Wrapper_For_AspNetCoreIndirect_Application_GetWeatherForecast = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::AspNetCoreIndirect.Application.GetWeatherForecast, global::System.Collections.Generic.IReadOnlyList<global::AspNetCoreIndirect.Application.WeatherForecast>>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace Mediator
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Console#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Console#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Ping, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::SimpleConsole.RequestHandlerWrapper<global::Ping, global::Pong>),
-                typeof(global::SimpleConsole.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::SimpleConsole.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::SimpleConsole.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::SimpleConsole.IContainerProbe), typeof(global::SimpleConsole.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::SimpleConsole.IContainerProbe), typeof(global::SimpleConsole.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsole.Internals.IContainerProbe), typeof(global::SimpleConsole.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsole.Internals.IContainerProbe), typeof(global::SimpleConsole.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::SimpleConsole.ContainerMetadata), typeof(global::SimpleConsole.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsole.Internals.ContainerMetadata), typeof(global::SimpleConsole.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace SimpleConsole
+namespace SimpleConsole.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace SimpleConsole
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace SimpleConsole
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace SimpleConsole
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace SimpleConsole
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace SimpleConsole
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace SimpleConsole
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace SimpleConsole
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::SimpleConsole.ContainerMetadata containerMetadata,
+            global::SimpleConsole.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace SimpleConsole
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::SimpleConsole.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
+        public readonly global::SimpleConsole.Internals.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace SimpleConsole
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsole.IContainerProbe>() is global::SimpleConsole.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsole.Internals.IContainerProbe>() is global::SimpleConsole.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::SimpleConsole.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::SimpleConsole.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace SimpleConsole
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Ping = sp.GetRequiredService<global::SimpleConsole.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
+            Wrapper_For_Ping = sp.GetRequiredService<global::SimpleConsole.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace SimpleConsole
 
         }
     }
+}
 
+namespace SimpleConsole
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace SimpleConsole
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::SimpleConsole.ContainerMetadata, global::SimpleConsole.Mediator> _containerMetadata;
+        private FastLazyValue<global::SimpleConsole.Internals.ContainerMetadata, global::SimpleConsole.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace SimpleConsole
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::SimpleConsole.ContainerMetadata, global::SimpleConsole.Mediator>(
-                self => self.Services.GetRequiredService<global::SimpleConsole.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::SimpleConsole.Internals.ContainerMetadata, global::SimpleConsole.Mediator>(
+                self => self.Services.GetRequiredService<global::SimpleConsole.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ConsoleAOT#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_ConsoleAOT#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Ping, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::SimpleConsoleAOT.RequestHandlerWrapper<global::Ping, global::Pong>),
-                typeof(global::SimpleConsoleAOT.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::SimpleConsoleAOT.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::SimpleConsoleAOT.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::SimpleConsoleAOT.IContainerProbe), typeof(global::SimpleConsoleAOT.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::SimpleConsoleAOT.IContainerProbe), typeof(global::SimpleConsoleAOT.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsoleAOT.Internals.IContainerProbe), typeof(global::SimpleConsoleAOT.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsoleAOT.Internals.IContainerProbe), typeof(global::SimpleConsoleAOT.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::SimpleConsoleAOT.ContainerMetadata), typeof(global::SimpleConsoleAOT.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::SimpleConsoleAOT.Internals.ContainerMetadata), typeof(global::SimpleConsoleAOT.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace SimpleConsoleAOT
+namespace SimpleConsoleAOT.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace SimpleConsoleAOT
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::SimpleConsoleAOT.ContainerMetadata containerMetadata,
+            global::SimpleConsoleAOT.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -679,7 +679,7 @@ namespace SimpleConsoleAOT
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::SimpleConsoleAOT.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
+        public readonly global::SimpleConsoleAOT.Internals.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
 
 
 
@@ -691,14 +691,14 @@ namespace SimpleConsoleAOT
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsoleAOT.IContainerProbe>() is global::SimpleConsoleAOT.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::SimpleConsoleAOT.Internals.IContainerProbe>() is global::SimpleConsoleAOT.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::SimpleConsoleAOT.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::SimpleConsoleAOT.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -713,7 +713,7 @@ namespace SimpleConsoleAOT
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Ping = sp.GetRequiredService<global::SimpleConsoleAOT.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
+            Wrapper_For_Ping = sp.GetRequiredService<global::SimpleConsoleAOT.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
 
 
 
@@ -722,7 +722,10 @@ namespace SimpleConsoleAOT
 
         }
     }
+}
 
+namespace SimpleConsoleAOT
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace SimpleConsoleAOT
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::SimpleConsoleAOT.ContainerMetadata, global::SimpleConsoleAOT.Mediator> _containerMetadata;
+        private FastLazyValue<global::SimpleConsoleAOT.Internals.ContainerMetadata, global::SimpleConsoleAOT.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace SimpleConsoleAOT
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::SimpleConsoleAOT.ContainerMetadata, global::SimpleConsoleAOT.Mediator>(
-                self => self.Services.GetRequiredService<global::SimpleConsoleAOT.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::SimpleConsoleAOT.Internals.ContainerMetadata, global::SimpleConsoleAOT.Mediator>(
+                self => self.Services.GetRequiredService<global::SimpleConsoleAOT.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_InternalMessages_Sample#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_InternalMessages_Sample#Mediator.g.verified.cs
@@ -61,25 +61,25 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::InternalMessages.Application.PingHandler), typeof(global::InternalMessages.Application.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>), typeof(global::InternalMessages.Application.PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
             services.TryAdd(new SD(typeof(global::InternalMessages.Application.PingPongedHandler), typeof(global::InternalMessages.Application.PingPongedHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::InternalMessages.Domain.PingPonged>), GetRequiredService<global::InternalMessages.Application.PingPongedHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>), typeof(global::Mediator.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
 
 
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -133,7 +133,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -213,7 +213,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -294,7 +294,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -374,7 +374,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -455,7 +455,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -535,7 +535,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -610,7 +610,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -684,27 +684,27 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong> Wrapper_For_InternalMessages_Domain_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong> Wrapper_For_InternalMessages_Domain_Ping;
 
 
 
 
 
 
-        public readonly global::Mediator.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged> Wrapper_For_InternalMessages_Domain_PingPonged;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged> Wrapper_For_InternalMessages_Domain_PingPonged;
 
         public readonly global::Mediator.ForeachAwaitPublisher NotificationPublisher;
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::InternalMessages.Domain.Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::InternalMessages.Domain.Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -717,20 +717,23 @@ namespace Mediator
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
 
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
-            notificationHandlerTypes.Add(typeof(global::InternalMessages.Domain.PingPonged), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::InternalMessages.Domain.PingPonged), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>>().Init(this, sp));
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_InternalMessages_Domain_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>>().Init(this, sp);
+            Wrapper_For_InternalMessages_Domain_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::InternalMessages.Domain.Ping, global::InternalMessages.Domain.Pong>>().Init(this, sp);
 
 
 
 
 
 
-            Wrapper_For_InternalMessages_Domain_PingPonged = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>>().Init(this, sp);
+            Wrapper_For_InternalMessages_Domain_PingPonged = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::InternalMessages.Domain.PingPonged>>().Init(this, sp);
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -742,7 +745,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -787,8 +790,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Notifications#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Notifications#Mediator.g.verified.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::Notification>), GetRequiredService<global::CatchAllNotificationHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::Notification>), GetRequiredService<global::ConcreteNotificationHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::Notification>), typeof(global::Mediator.NotificationHandlerWrapper<global::Notification>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::Notification>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::Notification>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<>), typeof(global::GenericNotificationHandler<>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
@@ -72,10 +72,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -129,7 +129,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -209,7 +209,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -290,7 +290,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -370,7 +370,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -451,7 +451,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -531,7 +531,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -606,7 +606,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -686,13 +686,13 @@ namespace Mediator
 
 
 
-        public readonly global::Mediator.NotificationHandlerWrapper<global::Notification> Wrapper_For_Notification;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::Notification> Wrapper_For_Notification;
 
         public readonly global::Mediator.ForeachAwaitPublisher NotificationPublisher;
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -711,7 +711,7 @@ namespace Mediator
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
 
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
-            notificationHandlerTypes.Add(typeof(global::Notification), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::Notification>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::Notification), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::Notification>>().Init(this, sp));
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
 
@@ -720,10 +720,13 @@ namespace Mediator
 
 
 
-            Wrapper_For_Notification = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::Notification>>().Init(this, sp);
+            Wrapper_For_Notification = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::Notification>>().Init(this, sp);
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -735,7 +738,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -780,8 +783,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Showcase#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Showcase#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IRequestHandler<global::Ping, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
-                typeof(global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
+                typeof(global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -71,9 +71,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::ErrorMessage>), GetRequiredService<global::ErrorNotificationHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::ErrorMessage>), GetRequiredService<global::StatsNotificationHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::ErrorMessage>), typeof(global::Mediator.NotificationHandlerWrapper<global::ErrorMessage>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::ErrorMessage>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::ErrorMessage>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<global::SuccessfulMessage>), GetRequiredService<global::StatsNotificationHandler>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.NotificationHandlerWrapper<global::SuccessfulMessage>), typeof(global::Mediator.NotificationHandlerWrapper<global::SuccessfulMessage>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::SuccessfulMessage>), typeof(global::Mediator.Internals.NotificationHandlerWrapper<global::SuccessfulMessage>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             services.Add(new SD(typeof(global::Mediator.INotificationHandler<>), typeof(global::GenericNotificationHandler<>), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
@@ -81,10 +81,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::FireAndForgetNotificationPublisher), typeof(global::FireAndForgetNotificationPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::FireAndForgetNotificationPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -138,7 +138,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -218,7 +218,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -299,7 +299,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -379,7 +379,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -460,7 +460,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -540,7 +540,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -615,7 +615,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -689,28 +689,28 @@ namespace Mediator
 
         public readonly global::System.Collections.Frozen.FrozenDictionary<global::System.Type, object> NotificationHandlerWrappers;
 
-        public readonly global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
+        public readonly global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong> Wrapper_For_Ping;
 
 
 
 
 
 
-        public readonly global::Mediator.NotificationHandlerWrapper<global::ErrorMessage> Wrapper_For_ErrorMessage;
-        public readonly global::Mediator.NotificationHandlerWrapper<global::SuccessfulMessage> Wrapper_For_SuccessfulMessage;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::ErrorMessage> Wrapper_For_ErrorMessage;
+        public readonly global::Mediator.Internals.NotificationHandlerWrapper<global::SuccessfulMessage> Wrapper_For_SuccessfulMessage;
 
         public readonly global::FireAndForgetNotificationPublisher NotificationPublisher;
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::FireAndForgetNotificationPublisher>();
 
             var requestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var commandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var queryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
+            requestHandlerTypes.Add(typeof(global::Ping), sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp));
             RequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(requestHandlerTypes);
             CommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(commandHandlerTypes);
             QueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(queryHandlerTypes);
@@ -723,22 +723,25 @@ namespace Mediator
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
 
             var notificationHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(2);
-            notificationHandlerTypes.Add(typeof(global::ErrorMessage), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::ErrorMessage>>().Init(this, sp));
-            notificationHandlerTypes.Add(typeof(global::SuccessfulMessage), sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::SuccessfulMessage>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::ErrorMessage), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::ErrorMessage>>().Init(this, sp));
+            notificationHandlerTypes.Add(typeof(global::SuccessfulMessage), sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::SuccessfulMessage>>().Init(this, sp));
             NotificationHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(notificationHandlerTypes);
 
-            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
+            Wrapper_For_Ping = sp.GetRequiredService<global::Mediator.Internals.RequestHandlerWrapper<global::Ping, global::Pong>>().Init(this, sp);
 
 
 
 
 
 
-            Wrapper_For_ErrorMessage = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::ErrorMessage>>().Init(this, sp);
-            Wrapper_For_SuccessfulMessage = sp.GetRequiredService<global::Mediator.NotificationHandlerWrapper<global::SuccessfulMessage>>().Init(this, sp);
+            Wrapper_For_ErrorMessage = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::ErrorMessage>>().Init(this, sp);
+            Wrapper_For_SuccessfulMessage = sp.GetRequiredService<global::Mediator.Internals.NotificationHandlerWrapper<global::SuccessfulMessage>>().Init(this, sp);
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -750,7 +753,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::FireAndForgetNotificationPublisher? _notificationPublisher;
         internal global::FireAndForgetNotificationPublisher NotificationPublisher
         {
@@ -795,8 +798,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Streaming#Mediator.g.verified.cs
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/SampleTests.Test_Streaming#Mediator.g.verified.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAdd(new SD(typeof(global::PingHandler), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(typeof(global::Mediator.IStreamRequestHandler<global::StreamPing, global::Pong>), typeof(global::PingHandler), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.Add(new SD(
-                typeof(global::Mediator.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>),
-                typeof(global::Mediator.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>),
+                typeof(global::Mediator.Internals.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>),
+                typeof(global::Mediator.Internals.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>),
                 global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
             ));
 
@@ -73,10 +73,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new SD(typeof(global::Mediator.ForeachAwaitPublisher), typeof(global::Mediator.ForeachAwaitPublisher), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
             services.TryAdd(new SD(typeof(global::Mediator.INotificationPublisher), sp => sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>(), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
-            services.Add(new SD(typeof(global::Mediator.IContainerProbe), typeof(global::Mediator.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe0), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.IContainerProbe), typeof(global::Mediator.Internals.ContainerProbe1), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
-            services.Add(new SD(typeof(global::Mediator.ContainerMetadata), typeof(global::Mediator.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
+            services.Add(new SD(typeof(global::Mediator.Internals.ContainerMetadata), typeof(global::Mediator.Internals.ContainerMetadata), global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton));
 
             return services;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 }
 
-namespace Mediator
+namespace Mediator.Internals
 {
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "3.0.0.0")]
     internal interface IMessageHandlerBase
@@ -128,7 +128,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public RequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -208,7 +208,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamRequestHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -289,7 +289,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public CommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -369,7 +369,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamCommandHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -450,7 +450,7 @@ namespace Mediator
         private global::Mediator.MessageHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public QueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -530,7 +530,7 @@ namespace Mediator
         private global::Mediator.StreamHandlerDelegate<TRequest, TResponse> _rootHandler = null!;
 
         public StreamQueryHandlerWrapper<TRequest, TResponse> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -605,7 +605,7 @@ namespace Mediator
         private global::Mediator.INotificationHandler<TNotification>[] _handlers = null!;
 
         public NotificationHandlerWrapper<TNotification> Init(
-            global::Mediator.ContainerMetadata containerMetadata,
+            global::Mediator.Internals.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
         {
@@ -682,7 +682,7 @@ namespace Mediator
 
 
 
-        public readonly global::Mediator.StreamRequestHandlerWrapper<global::StreamPing, global::Pong> Wrapper_For_StreamPing;
+        public readonly global::Mediator.Internals.StreamRequestHandlerWrapper<global::StreamPing, global::Pong> Wrapper_For_StreamPing;
 
 
 
@@ -691,7 +691,7 @@ namespace Mediator
 
         public ContainerMetadata(global::System.IServiceProvider sp)
         {
-            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.IContainerProbe>() is global::Mediator.IContainerProbe[];
+            ServicesUnderlyingTypeIsArray = sp.GetServices<global::Mediator.Internals.IContainerProbe>() is global::Mediator.Internals.IContainerProbe[];
 
             NotificationPublisher = sp.GetRequiredService<global::Mediator.ForeachAwaitPublisher>();
 
@@ -705,7 +705,7 @@ namespace Mediator
             var streamRequestHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(1);
             var streamCommandHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
             var streamQueryHandlerTypes = new global::System.Collections.Generic.Dictionary<global::System.Type, object>(0);
-            streamRequestHandlerTypes.Add(typeof(global::StreamPing), sp.GetRequiredService<global::Mediator.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>>().Init(this, sp));
+            streamRequestHandlerTypes.Add(typeof(global::StreamPing), sp.GetRequiredService<global::Mediator.Internals.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>>().Init(this, sp));
             StreamRequestHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamRequestHandlerTypes);
             StreamCommandHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamCommandHandlerTypes);
             StreamQueryHandlerWrappers = global::System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(streamQueryHandlerTypes);
@@ -716,13 +716,16 @@ namespace Mediator
 
 
 
-            Wrapper_For_StreamPing = sp.GetRequiredService<global::Mediator.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>>().Init(this, sp);
+            Wrapper_For_StreamPing = sp.GetRequiredService<global::Mediator.Internals.StreamRequestHandlerWrapper<global::StreamPing, global::Pong>>().Init(this, sp);
 
 
 
         }
     }
+}
 
+namespace Mediator
+{
     /// <summary>
     /// Generated code for Mediator implementation.
     /// This type is also registered as a DI service.
@@ -734,7 +737,7 @@ namespace Mediator
     public sealed partial class Mediator : global::Mediator.IMediator, global::Mediator.ISender, global::Mediator.IPublisher
     {
         internal readonly global::System.IServiceProvider Services;
-        private FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
+        private FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator> _containerMetadata;
         private global::Mediator.ForeachAwaitPublisher? _notificationPublisher;
         internal global::Mediator.ForeachAwaitPublisher NotificationPublisher
         {
@@ -779,8 +782,8 @@ namespace Mediator
         public Mediator(global::System.IServiceProvider sp)
         {
             Services = sp;
-            _containerMetadata = new FastLazyValue<global::Mediator.ContainerMetadata, global::Mediator.Mediator>(
-                self => self.Services.GetRequiredService<global::Mediator.ContainerMetadata>(),
+            _containerMetadata = new FastLazyValue<global::Mediator.Internals.ContainerMetadata, global::Mediator.Mediator>(
+                self => self.Services.GetRequiredService<global::Mediator.Internals.ContainerMetadata>(),
                 this
             );
         }

--- a/test/Mediator.Tests/SmokeTests.FastLazy.cs
+++ b/test/Mediator.Tests/SmokeTests.FastLazy.cs
@@ -2,7 +2,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using LazyContainerMetadata = Mediator.Mediator.FastLazyValue<Mediator.ContainerMetadata, Mediator.Mediator>;
+using LazyContainerMetadata = Mediator.Mediator.FastLazyValue<Mediator.Internals.ContainerMetadata, Mediator.Mediator>;
 
 namespace Mediator.Tests;
 
@@ -25,7 +25,7 @@ public partial class SmokeTests
 
         var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var threads = new Task<(ContainerMetadata Cache, long State)>[concurrency];
+        var threads = new Task<(Internals.ContainerMetadata Cache, long State)>[concurrency];
         for (int i = 0; i < concurrency; i++)
         {
             threads[i] = Task.Run(Thread);
@@ -43,7 +43,7 @@ public partial class SmokeTests
 
         Assert.All(handlers, h => Assert.Same(handler, h));
 
-        async Task<(ContainerMetadata Cache, long State)> Thread()
+        async Task<(Internals.ContainerMetadata Cache, long State)> Thread()
         {
             await start.Task;
 


### PR DESCRIPTION
There are some internals that are only meant to be referenced by `Mediator` and DI registration logic