### PR TITLE
Cleanup and improve initialization of models used during source generation

### DIFF
--- a/src/Mediator.SourceGenerator/Implementation/Analysis/CompilationAnalyzer.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Analysis/CompilationAnalyzer.cs
@@ -23,7 +23,6 @@ internal sealed class CompilationAnalyzer
 
     private readonly HashSet<RequestMessage> _requestMessages;
     private readonly HashSet<NotificationMessage> _notificationMessages;
-    private readonly HashSet<RequestMessageHandler> _requestMessageHandlers;
     private readonly HashSet<NotificationMessageHandler> _notificationMessageHandlers;
 
     public ImmutableArray<RequestMessageHandlerWrapperModel> RequestMessageHandlerWrappers;
@@ -76,7 +75,6 @@ internal sealed class CompilationAnalyzer
     {
         _context = context;
         _requestMessages = new();
-        _requestMessageHandlers = new();
         _notificationMessages = new();
         _notificationMessageHandlers = new();
         _baseHandlerSymbols = Array.Empty<INamedTypeSymbol>();
@@ -319,7 +317,6 @@ internal sealed class CompilationAnalyzer
                     )
                 ),
                 ToModelsSortedByInheritanceDepth(_notificationMessages, m => m.ToModel()),
-                _requestMessageHandlers.Select(x => x.ToModel()).ToImmutableEquatableArray(),
                 _notificationMessageHandlers.Select(x => x.ToModel()).ToImmutableEquatableArray(),
                 RequestMessageHandlerWrappers.ToImmutableEquatableArray(),
                 new NotificationPublisherTypeModel(
@@ -333,8 +330,7 @@ internal sealed class CompilationAnalyzer
                 ServiceLifetimeShort,
                 SingletonServiceLifetime,
                 IsTestRun,
-                ConfiguredViaAttribute,
-                ConfiguredViaConfiguration
+                ConfiguredViaAttribute
             );
 
             return model;
@@ -628,8 +624,6 @@ internal sealed class CompilationAnalyzer
                             {
                                 mapping.Add(requestMessageSymbol, handler);
                             }
-
-                            _requestMessageHandlers.Add(handler);
                         }
                         else
                         {

--- a/src/Mediator.SourceGenerator/Implementation/Models/CompilationModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/CompilationModel.cs
@@ -1,28 +1,44 @@
 ﻿namespace Mediator.SourceGenerator;
 
-internal record CompilationModel
+internal sealed record CompilationModel
 {
-    private readonly ImmutableEquatableArray<RequestMessageModel> _requestMessages;
-    private readonly ImmutableEquatableArray<NotificationMessageModel> _notificationMessages;
-    private readonly ImmutableEquatableArray<RequestMessageHandlerModel> _requestMessageHandlers;
-    private readonly ImmutableEquatableArray<NotificationMessageHandlerModel> _notificationMessageHandlers;
+    private const int ManyMessagesTreshold = 16;
 
     public CompilationModel(string mediatorNamespace, string generatorVersion)
     {
-        HasErrors = true;
         MediatorNamespace = mediatorNamespace;
         GeneratorVersion = generatorVersion;
-        _requestMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
-        _notificationMessages = ImmutableEquatableArray<NotificationMessageModel>.Empty;
-        _requestMessageHandlers = ImmutableEquatableArray<RequestMessageHandlerModel>.Empty;
-        _notificationMessageHandlers = ImmutableEquatableArray<NotificationMessageHandlerModel>.Empty;
+        HasErrors = true;
+        IsTestRun = false;
+        ConfiguredViaAttribute = false;
+        ServiceLifetime = "global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton";
+        ServiceLifetimeShort = "Singleton";
+        SingletonServiceLifetime = ServiceLifetime;
+        ServiceLifetimeIsSingleton = true;
+        ServiceLifetimeIsScoped = false;
+        ServiceLifetimeIsTransient = false;
+        ContainerMetadataField = "_containerMetadata.Value";
+        InternalsNamespace = $"{MediatorNamespace}.Internals";
+        TotalMessages = 0;
+        NotificationPublisherType = new("global::Mediator.ForeachAwaitPublisher", "ForeachAwaitPublisher");
+
         RequestMessageHandlerWrappers = ImmutableEquatableArray<RequestMessageHandlerWrapperModel>.Empty;
+        RequestMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        NotificationMessages = ImmutableEquatableArray<NotificationMessageModel>.Empty;
+        NotificationMessageHandlers = ImmutableEquatableArray<NotificationMessageHandlerModel>.Empty;
+        OpenGenericNotificationMessageHandlers = ImmutableEquatableArray<NotificationMessageHandlerModel>.Empty;
+
+        IRequestMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        ICommandMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        IQueryMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        IStreamRequestMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        IStreamQueryMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
+        IStreamCommandMessages = ImmutableEquatableArray<RequestMessageModel>.Empty;
     }
 
     public CompilationModel(
         ImmutableEquatableArray<RequestMessageModel> requestMessages,
         ImmutableEquatableArray<NotificationMessageModel> notificationMessages,
-        ImmutableEquatableArray<RequestMessageHandlerModel> requestMessageHandlers,
         ImmutableEquatableArray<NotificationMessageHandlerModel> notificationMessageHandlers,
         ImmutableEquatableArray<RequestMessageHandlerWrapperModel> requestMessageHandlerWrappers,
         NotificationPublisherTypeModel notificationPublisherType,
@@ -33,125 +49,119 @@ internal record CompilationModel
         string? serviceLifetimeShort,
         string? singletonServiceLifetime,
         bool isTestRun,
-        bool configuredViaAttribute,
-        bool configuredViaConfiguration
+        bool configuredViaAttribute
     )
     {
-        _requestMessages = requestMessages;
-        _notificationMessages = notificationMessages;
-        _requestMessageHandlers = requestMessageHandlers;
-        _notificationMessageHandlers = notificationMessageHandlers;
-        NotificationPublisherType = notificationPublisherType;
-        RequestMessageHandlerWrappers = requestMessageHandlerWrappers;
-        HasErrors = hasErrors;
         MediatorNamespace = mediatorNamespace;
         GeneratorVersion = generatorVersion;
+        HasErrors = hasErrors;
+        IsTestRun = isTestRun;
+        ConfiguredViaAttribute = configuredViaAttribute;
         ServiceLifetime = serviceLifetime;
         ServiceLifetimeShort = serviceLifetimeShort;
         SingletonServiceLifetime = singletonServiceLifetime;
-        IsTestRun = isTestRun;
-        ConfiguredViaAttribute = configuredViaAttribute;
-        ConfiguredViaConfiguration = configuredViaConfiguration;
+        ServiceLifetimeIsSingleton = serviceLifetimeShort == "Singleton";
+        ServiceLifetimeIsScoped = serviceLifetimeShort == "Scoped";
+        ServiceLifetimeIsTransient = serviceLifetimeShort == "Transient";
+        ContainerMetadataField = ServiceLifetimeIsSingleton ? "_containerMetadata.Value" : "_containerMetadata";
+        InternalsNamespace = $"{MediatorNamespace}.Internals";
+        TotalMessages = requestMessages.Count + notificationMessages.Count;
+        NotificationPublisherType = notificationPublisherType;
+
+        RequestMessageHandlerWrappers = requestMessageHandlerWrappers;
+        RequestMessages = new(requestMessages.Where(r => r.Handler is not null));
+        NotificationMessages = notificationMessages;
+        NotificationMessageHandlers = new(notificationMessageHandlers.Where(h => !h.IsOpenGeneric));
+        OpenGenericNotificationMessageHandlers = new(notificationMessageHandlers.Where(h => h.IsOpenGeneric));
+
+        IRequestMessages = new(requestMessages.Where(r => r.Handler is not null && r.MessageType == "Request"));
+        ICommandMessages = new(requestMessages.Where(r => r.Handler is not null && r.MessageType == "Command"));
+        IQueryMessages = new(requestMessages.Where(r => r.Handler is not null && r.MessageType == "Query"));
+        IStreamRequestMessages = new(
+            requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamRequest")
+        );
+        IStreamQueryMessages = new(requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamQuery"));
+        IStreamCommandMessages = new(
+            requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamCommand")
+        );
+
+        HasRequests = requestMessages.Any(r => r.Handler is not null && r.MessageType == "Request");
+        HasCommands = requestMessages.Any(r => r.Handler is not null && r.MessageType == "Command");
+        HasQueries = requestMessages.Any(r => r.Handler is not null && r.MessageType == "Query");
+        HasStreamRequests = requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamRequest");
+        HasStreamQueries = requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamQuery");
+        HasStreamCommands = requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamCommand");
+        HasNotifications = notificationMessages.Any();
+
+        var t = ManyMessagesTreshold;
+        var m = requestMessages;
+        HasManyRequests = m.Count(r => r.Handler is not null && r.MessageType == "Request") > t;
+        HasManyCommands = m.Count(r => r.Handler is not null && r.MessageType == "Command") > t;
+        HasManyQueries = m.Count(r => r.Handler is not null && r.MessageType == "Query") > t;
+        HasManyStreamRequests = m.Count(r => r.Handler is not null && r.MessageType == "StreamRequest") > t;
+        HasManyStreamQueries = m.Count(r => r.Handler is not null && r.MessageType == "StreamQuery") > t;
+        HasManyStreamCommands = m.Count(r => r.Handler is not null && r.MessageType == "StreamCommand") > t;
+        HasManyNotifications = notificationMessages.Count() > t;
+
+        HasAnyRequest = HasRequests || HasCommands || HasQueries;
+        HasAnyStreamRequest = HasStreamRequests || HasStreamQueries || HasStreamCommands;
+        HasAnyValueTypeStreamResponse = requestMessages.Any(r =>
+            r.MessageType.StartsWith("Stream") && r.ResponseIsValueType
+        );
     }
-
-    public ImmutableEquatableArray<RequestMessageHandlerWrapperModel> RequestMessageHandlerWrappers { get; }
-
-    public IEnumerable<RequestMessageModel> RequestMessages => _requestMessages.Where(r => r.Handler is not null);
-
-    public IEnumerable<NotificationMessageModel> NotificationMessages => _notificationMessages;
-
-    public int TotalMessages => _requestMessages.Count + _notificationMessages.Count;
-
-    public IEnumerable<RequestMessageHandlerModel> RequestMessageHandlers => _requestMessageHandlers;
-
-    public NotificationPublisherTypeModel NotificationPublisherType { get; }
-
-    public bool HasErrors { get; }
-
-    public IEnumerable<NotificationMessageHandlerModel> NotificationMessageHandlers =>
-        _notificationMessageHandlers.Where(h => !h.IsOpenGeneric);
-
-    public IEnumerable<NotificationMessageHandlerModel> OpenGenericNotificationMessageHandlers =>
-        _notificationMessageHandlers.Where(h => h.IsOpenGeneric);
-
-    public bool HasRequests => _requestMessages.Any(r => r.Handler is not null && r.MessageType == "Request");
-    public bool HasCommands => _requestMessages.Any(r => r.Handler is not null && r.MessageType == "Command");
-    public bool HasQueries => _requestMessages.Any(r => r.Handler is not null && r.MessageType == "Query");
-
-    private const int ManyMessagesTreshold = 16;
-
-    public bool HasManyRequests =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "Request") > ManyMessagesTreshold;
-    public bool HasManyCommands =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "Command") > ManyMessagesTreshold;
-    public bool HasManyQueries =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "Query") > ManyMessagesTreshold;
-
-    public bool HasStreamRequests =>
-        _requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamRequest");
-    public bool HasStreamQueries => _requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamQuery");
-    public bool HasStreamCommands =>
-        _requestMessages.Any(r => r.Handler is not null && r.MessageType == "StreamCommand");
-
-    public bool HasManyStreamRequests =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "StreamRequest") > ManyMessagesTreshold;
-    public bool HasManyStreamQueries =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "StreamQuery") > ManyMessagesTreshold;
-    public bool HasManyStreamCommands =>
-        _requestMessages.Count(r => r.Handler is not null && r.MessageType == "StreamCommand") > ManyMessagesTreshold;
-
-    public bool HasAnyRequest => HasRequests || HasCommands || HasQueries;
-
-    public bool HasAnyStreamRequest => HasStreamRequests || HasStreamQueries || HasStreamCommands;
-
-    public bool HasAnyValueTypeStreamResponse =>
-        _requestMessages.Any(r => r.MessageType.StartsWith("Stream") && r.ResponseIsValueType);
-
-    public bool HasNotifications => _notificationMessages.Any();
-    public bool HasManyNotifications => _notificationMessages.Count() > ManyMessagesTreshold;
-
-    public IEnumerable<RequestMessageModel> IRequestMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "Request");
-    public IEnumerable<RequestMessageModel> ICommandMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "Command");
-    public IEnumerable<RequestMessageModel> IQueryMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "Query");
-
-    public IEnumerable<RequestMessageModel> IStreamRequestMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamRequest");
-    public IEnumerable<RequestMessageModel> IStreamQueryMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamQuery");
-    public IEnumerable<RequestMessageModel> IStreamCommandMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.MessageType == "StreamCommand");
-
-    public IEnumerable<RequestMessageModel> IMessages =>
-        _requestMessages.Where(r => r.Handler is not null && !r.IsStreaming);
-    public IEnumerable<RequestMessageModel> IStreamMessages =>
-        _requestMessages.Where(r => r.Handler is not null && r.IsStreaming);
 
     public string MediatorNamespace { get; }
     public string GeneratorVersion { get; }
-
-    public string? ServiceLifetime { get; }
-
-    public string? ServiceLifetimeShort { get; }
-
-    public string? SingletonServiceLifetime { get; }
-
-    public bool ServiceLifetimeIsSingleton => ServiceLifetimeShort == "Singleton";
-
-    public string ContainerMetadataField =>
-        ServiceLifetimeIsSingleton ? "_containerMetadata.Value" : "_containerMetadata";
-
-    public bool ServiceLifetimeIsScoped => ServiceLifetimeShort == "Scoped";
-
-    public bool ServiceLifetimeIsTransient => ServiceLifetimeShort == "Transient";
-
+    public bool HasErrors { get; }
     public bool IsTestRun { get; }
-
     public bool ConfiguredViaAttribute { get; }
+    public string? ServiceLifetime { get; }
+    public string? ServiceLifetimeShort { get; }
+    public string? SingletonServiceLifetime { get; }
+    public bool ServiceLifetimeIsSingleton { get; }
+    public bool ServiceLifetimeIsScoped { get; }
+    public bool ServiceLifetimeIsTransient { get; }
+    public string ContainerMetadataField { get; }
+    public string InternalsNamespace { get; }
+    public int TotalMessages { get; }
 
-    public bool ConfiguredViaConfiguration { get; }
+    public NotificationPublisherTypeModel NotificationPublisherType { get; }
 
-    public string InternalsNamespace => $"{MediatorNamespace}.Internals";
+    public ImmutableEquatableArray<RequestMessageHandlerWrapperModel> RequestMessageHandlerWrappers { get; }
+
+    public ImmutableEquatableArray<RequestMessageModel> RequestMessages { get; }
+
+    public ImmutableEquatableArray<NotificationMessageModel> NotificationMessages { get; }
+
+    public ImmutableEquatableArray<NotificationMessageHandlerModel> NotificationMessageHandlers { get; }
+
+    public ImmutableEquatableArray<NotificationMessageHandlerModel> OpenGenericNotificationMessageHandlers { get; }
+
+    public ImmutableEquatableArray<RequestMessageModel> IRequestMessages { get; }
+    public ImmutableEquatableArray<RequestMessageModel> ICommandMessages { get; }
+    public ImmutableEquatableArray<RequestMessageModel> IQueryMessages { get; }
+
+    public ImmutableEquatableArray<RequestMessageModel> IStreamRequestMessages { get; }
+    public ImmutableEquatableArray<RequestMessageModel> IStreamQueryMessages { get; }
+    public ImmutableEquatableArray<RequestMessageModel> IStreamCommandMessages { get; }
+
+    public bool HasRequests { get; }
+    public bool HasCommands { get; }
+    public bool HasQueries { get; }
+    public bool HasStreamRequests { get; }
+    public bool HasStreamQueries { get; }
+    public bool HasStreamCommands { get; }
+    public bool HasNotifications { get; }
+
+    public bool HasManyRequests { get; }
+    public bool HasManyCommands { get; }
+    public bool HasManyQueries { get; }
+    public bool HasManyStreamRequests { get; }
+    public bool HasManyStreamQueries { get; }
+    public bool HasManyStreamCommands { get; }
+    public bool HasManyNotifications { get; }
+
+    public bool HasAnyRequest { get; }
+    public bool HasAnyStreamRequest { get; }
+    public bool HasAnyValueTypeStreamResponse { get; }
 }

--- a/src/Mediator.SourceGenerator/Implementation/Models/MessageHandlerModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/MessageHandlerModel.cs
@@ -4,24 +4,20 @@ namespace Mediator.SourceGenerator;
 
 internal abstract record MessageHandlerModel : SymbolMetadataModel
 {
-    private readonly int _typeArgumentsLength;
-
     protected MessageHandlerModel(INamedTypeSymbol symbol, CompilationAnalyzer analyzer)
         : base(symbol)
     {
-        ServiceLifetime = analyzer.ServiceLifetime;
+        var typeOfExpression = TypeOfExpression(symbol);
         ServiceRegistrationBlock =
-            $"services.TryAdd(new SD({TypeOfExpression(symbol)}, {TypeOfExpression(symbol)}, {ServiceLifetime}));";
-        _typeArgumentsLength = symbol.TypeArguments.Length;
+            $"services.TryAdd(new SD({typeOfExpression}, {typeOfExpression}, {analyzer.ServiceLifetime}));";
+        IsOpenGeneric = symbol.TypeArguments.Length > 0;
     }
 
-    public bool IsOpenGeneric => _typeArgumentsLength > 0;
+    public bool IsOpenGeneric { get; }
 
     public string ServiceRegistrationBlock { get; }
 
-    public string? ServiceLifetime { get; }
-
-    public static string TypeOfExpression(INamedTypeSymbol symbol, bool includeTypeParameters = true)
+    protected static string TypeOfExpression(INamedTypeSymbol symbol, bool includeTypeParameters = true)
     {
         var typeName = symbol.GetTypeSymbolFullName(includeTypeParameters: includeTypeParameters);
         var genericArguments = string.Empty;

--- a/src/Mediator.SourceGenerator/Implementation/Models/NotificationMessageHandlerModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/NotificationMessageHandlerModel.cs
@@ -8,7 +8,7 @@ internal sealed record NotificationMessageHandlerModel : MessageHandlerModel
         : base(symbol, analyzer)
     {
         OpenGenericServiceRegistrationBlock =
-            $"services.Add(new SD({OpenGenericTypeOfExpression}, {TypeOfExpression(symbol, false)}, {ServiceLifetime}));";
+            $"services.Add(new SD({OpenGenericTypeOfExpression}, {TypeOfExpression(symbol, false)}, {analyzer.ServiceLifetime}));";
     }
 
     public string OpenGenericServiceRegistrationBlock { get; }

--- a/src/Mediator.SourceGenerator/Implementation/Models/RequestMessageHandlerWrapperModel.cs
+++ b/src/Mediator.SourceGenerator/Implementation/Models/RequestMessageHandlerWrapperModel.cs
@@ -4,49 +4,35 @@ internal sealed record RequestMessageHandlerWrapperModel
 {
     public RequestMessageHandlerWrapperModel(string messageType, CompilationAnalyzer analyzer)
     {
-        MessageType = messageType;
         FullNamespace = $"global::{analyzer.MediatorNamespace}.Internals";
+        MessageType = messageType;
+        IsStreaming = messageType.StartsWith("Stream", StringComparison.Ordinal);
+        TypeName = $"{messageType}HandlerWrapper";
+        TypeNameWithGenericParameters = $"{TypeName}<TRequest, TResponse>";
+        InterfaceTypeNameWithGenericParameter = $"I{messageType}HandlerBase<TResponse>";
     }
 
-    public string MessageType { get; }
-
     public string FullNamespace { get; }
-
-    public string HandlerWrapperTypeNameImpl() => $"{MessageType}HandlerWrapper";
-
-    private string HandlerWrapperTypeFullName() => $"{FullNamespace}.{HandlerWrapperTypeNameImpl()}";
-
-    public string HandlerWrapperTypeNameWithGenericTypeArguments(string requestFullname, string responseFullname) =>
-        $"{HandlerWrapperTypeFullName()}<{requestFullname}, {responseFullname}>";
-
-    public string HandlerWrapperTypeOfExpression() => $"typeof({HandlerWrapperTypeFullName()}<,>)";
-
-    public string HandlerWrapperTypeNameWithGenericTypeParameters =>
-        $"{HandlerWrapperTypeNameImpl()}<TRequest, TResponse>";
-
-    public string HandlerWrapperTypeName => HandlerWrapperTypeNameImpl();
-
-    public bool IsStreaming => MessageType.StartsWith("Stream");
-
+    public string MessageType { get; }
+    public string TypeName { get; }
+    public bool IsStreaming { get; }
+    public string TypeNameWithGenericParameters { get; }
+    public string InterfaceTypeNameWithGenericParameter { get; }
     public string MessageHandlerDelegateName =>
         IsStreaming
             ? $"global::Mediator.StreamHandlerDelegate<TRequest, TResponse>"
             : $"global::Mediator.MessageHandlerDelegate<TRequest, TResponse>";
-
     public string PipelineHandlerTypeName =>
         IsStreaming
             ? "global::Mediator.IStreamPipelineBehavior<TRequest, TResponse>"
             : "global::Mediator.IPipelineBehavior<TRequest, TResponse>";
-
     public string ReturnTypeName =>
         IsStreaming
             ? "global::System.Collections.Generic.IAsyncEnumerable<TResponse>"
             : "global::System.Threading.Tasks.ValueTask<TResponse>";
-
     public string ReturnTypeNameWhenObject =>
         IsStreaming
             ? "global::System.Collections.Generic.IAsyncEnumerable<object?>"
             : "global::System.Threading.Tasks.ValueTask<object?>";
-
     public string HandlerBase => IsStreaming ? "IStreamMessageHandlerBase" : "IMessageHandlerBase";
 }

--- a/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {{~ for registration in message.HandlerServicesRegistrationBlock ~}}
             {{ registration }}
             {{~ end ~}}
-            services.Add(new SD(typeof(global::{{ InternalsNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), typeof(global::{{ InternalsNamespace }}.NotificationHandlerWrapper<{{ message.FullName }}>), {{ SingletonServiceLifetime }}));
+            services.Add(new SD(typeof({{ message.HandlerWrapperTypeNameWithGenericTypeArguments }}), typeof({{ message.HandlerWrapperTypeNameWithGenericTypeArguments }}), {{ SingletonServiceLifetime }}));
             {{~ end ~}}
 
             {{~ for handler in OpenGenericNotificationMessageHandlers ~}}
@@ -149,7 +149,7 @@ namespace {{ InternalsNamespace }}
 
     {{~ for wrapperType in RequestMessageHandlerWrappers ~}}
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "{{ GeneratorVersion }}")]
-    internal interface I{{ wrapperType.MessageType }}HandlerBase<TResponse> : {{ wrapperType.HandlerBase }}
+    internal interface {{ wrapperType.InterfaceTypeNameWithGenericParameter }} : {{ wrapperType.HandlerBase }}
     {
         {{ wrapperType.ReturnTypeName }} Handle(
             {{~ if !ServiceLifetimeIsSingleton ~}}
@@ -162,13 +162,13 @@ namespace {{ InternalsNamespace }}
     [global::System.CodeDom.Compiler.GeneratedCode("Mediator.SourceGenerator", "{{ GeneratorVersion }}")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.Diagnostics.DebuggerStepThroughAttribute]
-    internal sealed class {{ wrapperType.HandlerWrapperTypeNameWithGenericTypeParameters }} : I{{ wrapperType.MessageType }}HandlerBase<TResponse>
+    internal sealed class {{ wrapperType.TypeNameWithGenericParameters }} : {{ wrapperType.InterfaceTypeNameWithGenericParameter }}
         where TRequest : global::Mediator.I{{ wrapperType.MessageType }}<TResponse>
     {
         {{~ if ServiceLifetimeIsSingleton ~}}
         private {{ wrapperType.MessageHandlerDelegateName }} _rootHandler = null!;
 
-        public {{ wrapperType.HandlerWrapperTypeNameWithGenericTypeParameters }} Init(
+        public {{ wrapperType.TypeNameWithGenericParameters }} Init(
             global::{{ InternalsNamespace }}.ContainerMetadata containerMetadata,
             global::System.IServiceProvider sp
         )
@@ -811,7 +811,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in IRequestMessages ~}}
 
         /// <summary>
-        /// Send a request of type {{ message.RequestFullName }}.
+        /// Send a request of type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if request is null.
         {{- end }}
@@ -819,8 +819,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="request">Incoming request</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} request,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} request,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -833,7 +833,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in ICommandMessages ~}}
 
         /// <summary>
-        /// Send a command of type {{ message.RequestFullName }}.
+        /// Send a command of type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if command is null.
         {{- end }}
@@ -841,8 +841,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="command">Incoming command</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} command,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} command,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -855,7 +855,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in IQueryMessages ~}}
 
         /// <summary>
-        /// Send a query of type {{ message.RequestFullName }}.
+        /// Send a query of type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if query is null.
         {{- end }}
@@ -863,8 +863,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="query">Incoming query</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} query,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} query,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -877,7 +877,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in IStreamRequestMessages ~}}
 
         /// <summary>
-        /// Create a stream from request type {{ message.RequestFullName }}.
+        /// Create a stream from request type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if request is null.
         {{- end }}
@@ -885,8 +885,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="request">Incoming request</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} request,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} request,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -899,7 +899,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in IStreamCommandMessages ~}}
 
         /// <summary>
-        /// Create a stream from command type {{ message.RequestFullName }}.
+        /// Create a stream from command type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if command is null.
         {{- end }}
@@ -907,8 +907,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="command">Incoming command</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} command,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} command,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -921,7 +921,7 @@ namespace {{ MediatorNamespace }}
         {{~ for message in IStreamQueryMessages ~}}
 
         /// <summary>
-        /// Create a stream from query type {{ message.RequestFullName }}.
+        /// Create a stream from query type {{ message.FullName }}.
         {{- if message.IsClass }}
         /// Throws <see cref="global::System.ArgumentNullException"/> if query is null.
         {{- end }}
@@ -929,8 +929,8 @@ namespace {{ MediatorNamespace }}
         /// <param name="query">Incoming query</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Awaitable task</returns>
-        {{ message.AccessibilityModifier }} {{ message.AsyncReturnType }} {{ message.AsyncMethodName }}(
-            {{ message.RequestFullName }} query,
+        {{ message.AccessibilityModifier }} {{ message.ReturnType }} {{ message.MethodName }}(
+            {{ message.FullName }} query,
             global::System.Threading.CancellationToken cancellationToken = default
         )
         {
@@ -968,12 +968,12 @@ namespace {{ MediatorNamespace }}
             switch (request)
             {
                 {{~ for message in IRequestMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     if (typeof(TResponse) == typeof({{ message.ResponseFullNameWithoutReferenceNullability }}))
                     {
                         var task = Send(r, cancellationToken);
-                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
+                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
                     }
                     return SendAsync(request, cancellationToken);
                 }
@@ -1008,7 +1008,7 @@ namespace {{ MediatorNamespace }}
             switch (request)
             {
                 {{~ for message in IRequestMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var response = await Send(r, cancellationToken);
                     return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ResponseFullName }}, TResponse>(ref response);
@@ -1054,10 +1054,10 @@ namespace {{ MediatorNamespace }}
             switch (request)
             {
                 {{~ for message in IStreamRequestMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var task = CreateStream(r, cancellationToken);
-                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
+                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
                 }
                 {{~ end ~}}
                 default:
@@ -1115,12 +1115,12 @@ namespace {{ MediatorNamespace }}
             switch (command)
             {
                 {{~ for message in ICommandMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     if (typeof(TResponse) == typeof({{ message.ResponseFullNameWithoutReferenceNullability }}))
                     {
                         var task = Send(r, cancellationToken);
-                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
+                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
                     }
                     return SendAsync(command, cancellationToken);
                 }
@@ -1155,7 +1155,7 @@ namespace {{ MediatorNamespace }}
             switch (command)
             {
                 {{~ for message in ICommandMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var response = await Send(r, cancellationToken);
                     return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ResponseFullName }}, TResponse>(ref response);
@@ -1201,10 +1201,10 @@ namespace {{ MediatorNamespace }}
             switch (command)
             {
                 {{~ for message in IStreamCommandMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var task = CreateStream(r, cancellationToken);
-                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
+                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
                 }
                 {{~ end ~}}
                 default:
@@ -1262,12 +1262,12 @@ namespace {{ MediatorNamespace }}
             switch (query)
             {
                 {{~ for message in IQueryMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     if (typeof(TResponse) == typeof({{ message.ResponseFullNameWithoutReferenceNullability }}))
                     {
                         var task = Send(r, cancellationToken);
-                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
+                        return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Threading.Tasks.ValueTask<TResponse>>(ref task);
                     }
                     return SendAsync(query, cancellationToken);
                 }
@@ -1302,7 +1302,7 @@ namespace {{ MediatorNamespace }}
             switch (query)
             {
                 {{~ for message in IQueryMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var response = await Send(r, cancellationToken);
                     return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ResponseFullName }}, TResponse>(ref response);
@@ -1348,10 +1348,10 @@ namespace {{ MediatorNamespace }}
             switch (query)
             {
                 {{~ for message in IStreamQueryMessages ~}}
-                case {{ message.RequestFullName }} r:
+                case {{ message.FullName }} r:
                 {
                     var task = CreateStream(r, cancellationToken);
-                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.AsyncReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
+                    return global::System.Runtime.CompilerServices.Unsafe.As<{{ message.ReturnType }}, global::System.Collections.Generic.IAsyncEnumerable<TResponse>>(ref task);
                 }
                 {{~ end ~}}
                 default:
@@ -1414,7 +1414,7 @@ namespace {{ MediatorNamespace }}
                     switch (request)
                     {
                         {{~ for message in IRequestMessages ~}}
-                        case {{ message.RequestFullName }} r: return await Send(r, cancellationToken);
+                        case {{ message.FullName }} r: return await Send(r, cancellationToken);
                         {{~ end ~}}
                         default:
                         {
@@ -1438,7 +1438,7 @@ namespace {{ MediatorNamespace }}
                     switch (command)
                     {
                         {{~ for message in ICommandMessages ~}}
-                        case {{ message.RequestFullName }} r: return await Send(r, cancellationToken);
+                        case {{ message.FullName }} r: return await Send(r, cancellationToken);
                         {{~ end ~}}
                         default:
                         {
@@ -1462,7 +1462,7 @@ namespace {{ MediatorNamespace }}
                     switch (query)
                     {
                         {{~ for message in IQueryMessages ~}}
-                        case {{ message.RequestFullName }} r: return await Send(r, cancellationToken);
+                        case {{ message.FullName }} r: return await Send(r, cancellationToken);
                         {{~ end ~}}
                         default:
                         {
@@ -1513,7 +1513,7 @@ namespace {{ MediatorNamespace }}
                     switch (request)
                     {
                         {{~ for message in IStreamRequestMessages ~}}
-                        case {{ message.RequestFullName }} m:
+                        case {{ message.FullName }} m:
                         {
                             {{~ if message.ResponseIsValueType ~}}
                             var value = CreateStream(m, cancellationToken);
@@ -1545,7 +1545,7 @@ namespace {{ MediatorNamespace }}
                     switch (command)
                     {
                         {{~ for message in IStreamCommandMessages ~}}
-                        case {{ message.RequestFullName }} m:
+                        case {{ message.FullName }} m:
                         {
                             {{~ if message.ResponseIsValueType ~}}
                             var value = CreateStream(m, cancellationToken);
@@ -1577,7 +1577,7 @@ namespace {{ MediatorNamespace }}
                     switch (query)
                     {
                         {{~ for message in IStreamQueryMessages ~}}
-                        case {{ message.RequestFullName }} m:
+                        case {{ message.FullName }} m:
                         {
                             {{~ if message.ResponseIsValueType ~}}
                             var value = CreateStream(m, cancellationToken);


### PR DESCRIPTION
* Remove unused properties from models
* Initialize model properties in constructor (a lot of the properties are used multiple times)

In general lots of low haning perf fruit in the analyzer/source generator itself. Doesn't impact end-to-end latency of source generation though (slightly less allocations)