### PR TITLE
Fix HasManyCommands typo in the template

### DIFF
--- a/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
+++ b/src/Mediator.SourceGenerator/Implementation/resources/Mediator.sbn-cs
@@ -1177,7 +1177,7 @@ namespace {{ MediatorNamespace }}
 
         private async global::System.Threading.Tasks.ValueTask<TResponse> SendAsync<TResponse>(
             global::Mediator.ICommand<TResponse> command,
-            {{~ if HasManyRequests ~}}
+            {{~ if HasManyCommands ~}}
             object handlerObj,
             {{~ end ~}}
             global::System.Threading.CancellationToken cancellationToken = default


### PR DESCRIPTION
Fixes typo for HasManyCommands, similar to the HasManyQueries fix in #190. 