### PR TITLE
Use MSBuild for restore target when building netfx sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,12 +120,22 @@ jobs:
       run: .\Console\bin\Debug\Console.NetFramework.exe
 
   publish:
+    if: ${{ always() }}
     needs: [build, samples-net, samples-netfx]
     runs-on: ubuntu-latest
 
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
     steps:
+    - name: Check for failures
+      run: exit 1
+      if: >-
+        ${{
+             contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+          || contains(needs.*.result, 'skipped')
+        }}
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # depth is needed for nbgv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
       uses: nuget/setup-nuget@v2
 
     - name: Restore Packages
-      run: nuget restore Console.sln
+      run: msbuild Console.sln -t:Restore
 
     - name: Build solution
       run: msbuild Console.sln -t:Rebuild

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Abstract_Handler_Program.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Abstract_Handler_Program.verified.txt
@@ -1,14 +1,17 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0005,
-      Title: MediatorGenerator message warning,
+      Message: MediatorGenerator found message without any registered handler: Some.Nested.Types.Program.Ping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found message without any registered handler: {0},
-      Message: MediatorGenerator found message without any registered handler: Some.Nested.Types.Program.Ping,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0005,
+        Title: MediatorGenerator message warning,
+        MessageFormat: MediatorGenerator found message without any registered handler: {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Cast_Lifetime_Config.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Cast_Lifetime_Config.verified.txt
@@ -1,14 +1,16 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Configuratoin_Conflict.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Configuratoin_Conflict.verified.txt
@@ -1,14 +1,16 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0006,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found conflicting configuration - both MediatorOptions and MediatorOptionsAttribute configuration are being used.,
       Message: MediatorGenerator found conflicting configuration - both MediatorOptions and MediatorOptionsAttribute configuration are being used.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0006,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator found conflicting configuration - both MediatorOptions and MediatorOptionsAttribute configuration are being used.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Duplicate_Handlers.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Duplicate_Handlers.verified.txt
@@ -1,14 +1,17 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0001,
-      Title: MediatorGenerator multiple handlers,
+      Message: MediatorGenerator found multiple handlers of message type DuplicatePingHandler,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found multiple handlers of message type {0},
-      Message: MediatorGenerator found multiple handlers of message type DuplicatePingHandler,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0001,
+        Title: MediatorGenerator multiple handlers,
+        MessageFormat: MediatorGenerator found multiple handlers of message type {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Handler_Type.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Handler_Type.verified.txt
@@ -1,24 +1,30 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0002,
-      Title: MediatorGenerator invalid handler,
+      Message: MediatorGenerator found invalid handler type PingHandler,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found invalid handler type {0},
-      Message: MediatorGenerator found invalid handler type PingHandler,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0002,
+        Title: MediatorGenerator invalid handler,
+        MessageFormat: MediatorGenerator found invalid handler type {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     },
     {
-      Id: MSG0005,
-      Title: MediatorGenerator message warning,
+      Message: MediatorGenerator found message without any registered handler: Ping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found message without any registered handler: {0},
-      Message: MediatorGenerator found message without any registered handler: Ping,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0005,
+        Title: MediatorGenerator message warning,
+        MessageFormat: MediatorGenerator found message without any registered handler: {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Variable_In_Config.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Invalid_Variable_In_Config.verified.txt
@@ -1,14 +1,16 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_Errors.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Multiple_Errors.verified.txt
@@ -1,24 +1,30 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0001,
-      Title: MediatorGenerator multiple handlers,
+      Message: MediatorGenerator found multiple handlers of message type DuplicatePingHandler,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found multiple handlers of message type {0},
-      Message: MediatorGenerator found multiple handlers of message type DuplicatePingHandler,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0001,
+        Title: MediatorGenerator multiple handlers,
+        MessageFormat: MediatorGenerator found multiple handlers of message type {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     },
     {
-      Id: MSG0002,
-      Title: MediatorGenerator invalid handler,
+      Message: MediatorGenerator found invalid handler type StructPingHandler,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found invalid handler type {0},
-      Message: MediatorGenerator found invalid handler type StructPingHandler,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0002,
+        Title: MediatorGenerator invalid handler,
+        MessageFormat: MediatorGenerator found invalid handler type {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Request_Without_Handler_Warning.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Request_Without_Handler_Warning.verified.txt
@@ -1,14 +1,17 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0005,
-      Title: MediatorGenerator message warning,
+      Message: MediatorGenerator found message without any registered handler: Some.Nested.Types.Program.Ping,
       Severity: Warning,
       WarningLevel: 1,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator found message without any registered handler: {0},
-      Message: MediatorGenerator found message without any registered handler: Some.Nested.Types.Program.Ping,
-      Category: MediatorGenerator
+      Descriptor: {
+        Id: MSG0005,
+        Title: MediatorGenerator message warning,
+        MessageFormat: MediatorGenerator found message without any registered handler: {0},
+        Category: MediatorGenerator,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Lifetime_Variable_In_Config.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Lifetime_Variable_In_Config.verified.txt
@@ -1,14 +1,16 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Namespace_Variable_In_Config.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Namespace_Variable_In_Config.verified.txt
@@ -1,24 +1,28 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     },
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }

--- a/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Variables_In_Config.verified.txt
+++ b/test/Mediator.SourceGenerator.Tests/_snapshots/ReportingTests.Test_Unassigned_Variables_In_Config.verified.txt
@@ -1,24 +1,28 @@
 ﻿{
   Diagnostics: [
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     },
     {
-      Id: MSG0007,
-      Title: MediatorGenerator configuration error,
-      Severity: Error,
-      WarningLevel: 0,
-      Location: : (0,0)-(0,0),
-      MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
       Message: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
-      Category: MediatorGenerator
+      Severity: Error,
+      Descriptor: {
+        Id: MSG0007,
+        Title: MediatorGenerator configuration error,
+        MessageFormat: MediatorGenerator cannot parse MediatorOptions-based configuration. Only compile-time constant values can be used in MediatorOptions configuration.,
+        Category: MediatorGenerator,
+        DefaultSeverity: Error,
+        IsEnabledByDefault: true
+      }
     }
   ]
 }


### PR DESCRIPTION
Had some issues with building the netfx sample in pipelines:
![image](https://github.com/user-attachments/assets/8d9c1c90-dac9-4696-8921-0e0d29bc6848)


Related issue: https://github.com/NuGet/Home/issues/7512


Some diff in snapshots due to https://github.com/martinothamar/Mediator/pull/192 being merged without snapshots being updated.
The "Improve publish check" commit ensures the `publish` job is failed (it is in required checks in the rulesets) if dep jobs aren't run successfully (previously it was "skipped successfully" if `needs` jobs failed)