### PR TITLE
Docs(CPM): Add information how to setup Mediator.SourceGenerator using CPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,14 @@ With Central Package Management (CPM):
 or, if you prefer to handle the `PrivateAssets` and `IncludeAssets` centrally too, instead of repeating them in each project file, you can add this to `Directory.Build.props`:
 
 ```xml
-<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-<PackageReference Update="Mediator.SourceGenerator"
-                    PrivateAssets="all"
-                    IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+<PropertyGroup>
+  <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Update="Mediator.SourceGenerator"
+                      PrivateAssets="all"
+                      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+</ItemGroup>
 ```
 
 so your `<YourProject>.csproj` can be simplified to:


### PR DESCRIPTION
This pull request updates the `README.md` to provide clearer and more comprehensive documentation for installing and configuring the Mediator library, especially around package management options. The changes focus on improving instructions for both Central Package Management (CPM) and non-CPM setups, clarifying usage, and enhancing the overall structure and detail of the documentation.


## Why is this needed

The current Version of the package installation guide only introduces us to non-CPM setup (`<PackageReference>` only and `3.0.*` floating version numbers)
- `Directory.Packages.props` requires using `<PackageVersion>`
- **floating version numbers are not supported by CPM** by default and are returning `NU1011` Error Code, without adding `CentralPackageManagementFloatingVersionsEnabled>true</CentralPackageManagementFloatingVersionsEnabled>`
  *this is not recommended* from official side, as you can find now linked in the Alert box
  **BUT** it makes sense to tell about this, because you are using this for the other Package setups
- **Avoiding unrequired builderplate code:** Instead of adding <PrivateAssets> and <IncludeAssets> to each Project  , which uses `Mediator.SourceGenerator` in our Solution, we can add them centrally, but in `Directory.Build.props` instead, to update the `Directory.Packages.props`, which does not support setting those properties

Assuming that the best Practice, especially for larger Solutions in .NET is to use Central Package Management AND the `Mediator.SourceGenerator` Package recommends/requires <PrivateAssets> and <IncludeAssets> Properties to be set, it makes sense to enhance the User Expirience by adding this information so he didn't get the NU Error Code.

## Key Changes

### Documentation improvements:**

* Expanded the documentation to clearly differentiate installation instructions for dotnet CLI, non-CPM, and CPM setups, including detailed examples for each approach and best practices for CPM users.
* Added notes and warnings regarding floating versions with CPM, referencing official NuGet documentation for further guidance.

### Fixes Markdown linting/violation:**

* Converted `-` to `*` bullet point lists, to fix markdown linting (except from auto generated TOC)
* Added blank lines between text and lists and removed unnecessary blank lines
