### PR TITLE
Add IH alternative lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ There are various options for Mediator implementations in the .NET ecosystem. He
 
 * [MediatR](https://github.com/LuckyPennySoftware/MediatR) - the original reflection-based implementation (in-memory only)
 * Mediator (this library) - keeps a very similar API to MediatR, but with improved performance and NativeAoT-friendliness (in-memory only) in part due to sourcegenerators
+* [Immediate.Handlers](https://github.com/immediateplatform/immediate.handlers) - another source-generator based mediator implementation (in-memory only)
 * [Foundatio.Mediator](https://github.com/FoundatioFx/Foundatio.Mediator) - different, conventions based API. Also sourcegenerator-based (in-memory only)
 * [Wolverine](https://wolverinefx.net/) (part of the critterstack) - also conventions based, is a larger framework that also offers async/distributed messaging
 * [MassTransit](https://masstransit.io/) - also offers a mediator implementation, and also offers async/distributed messaging


### PR DESCRIPTION
Also, if you would like to see an expanded set of benchmarks comparing the various mediator pattern libraries, please review https://github.com/ImmediatePlatform/MediatorBenchmarks. This library and IH are consistently the fastest across all of the patterns.